### PR TITLE
Change d3 script source to cdn.jsdelivr.net

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "js-cookie": "^3.0.1",
     "popper.js": "^1.15.0",
     "stockfish.js": "^10.0.2",
-    "d3": "^7.7.0"
+    "d3": "^7.8.0"
   },
   "devDependencies": {
     "@types/bootstrap": "^5.1.7",

--- a/play.html
+++ b/play.html
@@ -463,7 +463,7 @@
   </footer>
   <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha384-ZvpUoO/+PpLXR1lu4jmpXWu80pZlYUAfxl5NsBMWOEPSjUn/6Z/hRTt8+pR6L4N2" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
-  <script src="https://d3js.org/d3.v7.min.js" integrity="sha384-FqCxjxSzZ2chJW6LDlJXTiVLE7pWdzHM2+0AF+i1VzrIVBBH8g67Xecjmx1tZ/YR" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/d3@7.8.0/dist/d3.min.js" integrity="sha384-BfdMhEKmGjfIcPlLK2EXeY8IW+8aVgSwDo8P3DHR4+iceT2QW/ygYkMeZ2dZ77j4" crossorigin="anonymous"></script>
   <script defer type="text/javascript" src="www/js/bundle.js"></script>
   <script>
     window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;


### PR DESCRIPTION
Thanks for merging all my changes. It was all working nicely the last few weeks, but just by coincidence it broke today.
They updated d3 on their website which broke the integrity SHA in the <script> tag. I've changed it to get a specific version
from jsdelivr CDN instead. Sorry for the inconvenience.
If you ever have any questions about the merged code, I'm always around. 