### PR TITLE
Bugs lobby matchrequests

### DIFF
--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -375,3 +375,9 @@ ul.list-striped > li {
               0 4px 6px -4px rgba(0, 0, 0, 0.2),
               0 -4px 6px -4px rgba(0, 0, 0, 0.2);
 }
+
+/* Fix margin collapse glitch */
+#lobby-table .btn:not(:last-child) {
+  margin: 0px;
+  border-bottom: none;  
+}

--- a/play.html
+++ b/play.html
@@ -102,7 +102,7 @@
                                   <span class="input-group-text" id="opponent-player">Play against</span>
                                   <input type="text" class="form-control" id="opponent-player-name" placeholder="Anyone" aria-describedby="opponent-player" spellcheck="false">
                                 </div>
-                                <div class="center pane-status" id="play-pane-status" style="display: none"></div>
+                                <div class="center pane-status" id="pairing-pane-status" style="display: none"></div>
                                 <a href="#" class="btn btn-outline-secondary btn-md disabled p-0" role="button" aria-disabled="true"><span class="me-2 fa fa-bolt" aria-hidden="false"></span>Lightning</a>
                                 <div class="btn-group" role="group" aria-label="Lightning">
                                   <button type="button" class="w-100 btn btn-outline-secondary btn-md" href="#" onclick="getGame(1,0);">1 min</button>
@@ -150,9 +150,23 @@
                                 </div>
                               </div>
                             </div>
-                            <div class="tab-pane fade" id="pills-lobby" role="tabpanel" aria-labelledby="pills-lobby-tab">
-                              <div class="d-grid gap-2">
-                                <div class="btn-group-vertical" id="lobby-table"></div>
+                            <div class="tab-pane fade h-100" id="pills-lobby" role="tabpanel" aria-labelledby="pills-lobby-tab">
+                              <div class="d-flex flex-column h-100">
+                                <div class="pane-status" id="lobby-pane-status" style="display: none"></div>
+                                <div id="lobby" class="flex-grow-1" style="min-height: 0">
+                                  <div class="d-flex flex-column h-100">
+                                    <div class="center p-2">
+                                      <div class="form-check form-switch">
+                                        <input class="form-check-input" type="checkbox" id="lobby-show-computers">
+                                        <label class="form-check-label" for="lobby-show-computers">Show Computer Opponents</label>
+                                      </div>
+                                    </div>
+                                    <div class="flex-grow-1 overflow-auto d-flex" style="min-height: 0; flex-direction: column-reverse">
+                                      <div style="flex: 1 1 0"></div> <!-- this line and the column-reverse in the line above create an auto-scroll that only scrolls when at the bottom (without any JS amazing!) -->
+                                      <div class="btn-group-vertical w-100" id="lobby-table"></div>
+                                    </div>
+                                  </div>
+                                </div>
                               </div>
                             </div>
                           </div>

--- a/play.html
+++ b/play.html
@@ -265,7 +265,7 @@
                   <span class="fa fa-flag-o" aria-hidden="false"></span>
                 </button>
               </div>
-              <div id="viewing-game-buttons" class="btn-toolbar center m-auto w-100">
+              <div id="viewing-game-buttons" class="btn-toolbar center w-100">
                 <button type="button" id="show-status-panel" class="btn btn-outline-secondary btn-md" title="Analyze Game" style="display: none">Analyze</button>         
               </div>
             </div>

--- a/play.html
+++ b/play.html
@@ -98,11 +98,12 @@
                           <div class="tab-content flex-grow-1 overflow-auto" style="min-height: 0">
                             <div class="tab-pane fade show active" id="pills-pairing" role="tabpanel" aria-labelledby="pills-pairing-tab">                            
                               <div class="btn-group-vertical btn-block center" role="group" aria-label="New Game Menu">
+                                <div class="pane-status" id="matches-status" style="display: none"></div>
+                                <div class="center pane-status" id="pairing-pane-status" style="display: none"></div>
                                 <div class="input-group">
                                   <span class="input-group-text" id="opponent-player">Play against</span>
                                   <input type="text" class="form-control" id="opponent-player-name" placeholder="Anyone" aria-describedby="opponent-player" spellcheck="false">
                                 </div>
-                                <div class="center pane-status" id="pairing-pane-status" style="display: none"></div>
                                 <a href="#" class="btn btn-outline-secondary btn-md disabled p-0" role="button" aria-disabled="true"><span class="me-2 fa fa-bolt" aria-hidden="false"></span>Lightning</a>
                                 <div class="btn-group" role="group" aria-label="Lightning">
                                   <button type="button" class="w-100 btn btn-outline-secondary btn-md" href="#" onclick="getGame(1,0);">1 min</button>
@@ -174,6 +175,7 @@
                       </div>
                       <div class="tab-pane fade h-100" id="pills-observe" role="tabpanel" aria-labelledby="pills-observe-tab">
                         <div class="d-flex flex-column h-100">
+                          <div class="center pane-status" id="observe-pane-status"></div>
                           <form id="observe-user">
                             <div class="input-group">
                               <span class="input-group-text" id="observe-user-group">Observe</span>
@@ -181,12 +183,12 @@
                               <button type="submit" class="btn btn-outline-secondary btn-md" id="observe-go">Go</button>
                             </div>
                           </form>
-                          <div class="center pane-status" id="observe-pane-status"></div>
                           <div class="flex-grow-1 overflow-auto" style="min-height: 0" id="games-table"></div>
                         </div>
                       </div>
                       <div class="tab-pane fade h-100" id="pills-examine" role="tabpanel" aria-labelledby="pills-examine-tab">
                         <div class="d-flex flex-column h-100">
+                          <div class="center pane-status" id="examine-pane-status"></div>
                           <form id="examine-user">
                             <div class="input-group" id="examine-user-group">
                               <span class="input-group-text" id="examine-user-label">History</span>
@@ -194,7 +196,6 @@
                               <button type="submit" class="btn btn-outline-secondary btn-md" id="examine-go">Go</button>
                             </div>
                           </form>
-                          <div class="center pane-status" id="examine-pane-status"></div>
                           <div class="flex-grow-1 overflow-auto" style="min-height: 0" id="history-table"></div>
                         </div>
                       </div>

--- a/src/session.ts
+++ b/src/session.ts
@@ -44,7 +44,7 @@ export class Session {
 
   constructor(onRecv: (msg: any) => void, user?: string, pass?: string) {
     this.connected = false;
-    this.user = '';
+    this.user = user;
     this.onRecv = onRecv;
     this.connect(user, pass);
   }
@@ -58,16 +58,18 @@ export class Session {
   }
 
   public setUser(user: string): void {
+    $('#chat-status').html('<span style="overflow: hidden; text-overflow: ellipsis"><span class="fa fa-circle" aria-hidden="false"></span>&nbsp;<span class="h6">' + user + '</span></span>');
+    if(!this.user) { // Only display popover if this is a new user
+      $('#chat-status').popover({
+        animation: true,
+        content: 'Connected as ' + user + '. Click here to connect as a different user!',
+        placement: 'top',
+      });
+      $('#chat-status').popover('show');
+      setInterval(() => $('#chat-status').popover('dispose'), 3600);
+    }
     this.connected = true;
     this.user = user;
-    $('#chat-status').html('<span style="overflow: hidden; text-overflow: ellipsis"><span class="fa fa-circle" aria-hidden="false"></span>&nbsp;<span class="h6">' + user + '</span></span>');
-    $('#chat-status').popover({
-      animation: true,
-      content: 'Connected as ' + user + '. Click here to connect as a different user!',
-      placement: 'top',
-    });
-    $('#chat-status').popover('show');
-    setInterval(() => $('#chat-status').popover('dispose'), 3600);
   }
 
   public isConnected(): boolean {


### PR DESCRIPTION
First commit is just some misc bug fixes
Second commit is some improvements and bug fixes to the lobby panel, in particular:
- Lobby table now auto-scrolls to the bottom to keep up with new entries
- Added 'Show Computer Opponents' switch, since I feel like the Computer opponents were clogging up the list. Although a long term solution is probably to make a seek graph, but I was too lazy for that. 
- Added support for 'manual' seek requests.
Also appending (C) suffix to Computers in the Observe panel now to make it clearer. Doing this by retrieving the =computer list on connection to server and cross-referencing names.

Third commit is a new way of showing your own seek and match requests.  Showing them in a modal over the board doesn't work too well on mobile, since the user would have to scroll down to see it. So I thought it might be good to show them in the Play tab instead. I also tweaked the code so that you can cancel individual requests and it's a bit more responsive to the user using commands like 'unseek' or 'withdraw' in the console etc. The biggest downside of doing it this way is that because the seeks are displayed above the buttons, if the user tries to click multiple buttons quickly, the buttons jump downwards suddenly after clicking the first one which can take them by surprise. So to get around this, I put a 1 second timer in before displaying the text, so that the user has time to click a few buttons first. Bit of a hack, but maybe good enough. Let me know what you think?