### PR TITLE
Disable hover state for buttons on mobile (because it looks stupid)

### DIFF
--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -323,6 +323,22 @@ ul.list-striped > li {
   }
 }
 
+/* Turn hover state off for buttons on devices with no mouse (mobile) because it looks stupid */
+/* We achieve this by setting the hover color to match the normal button color */
+@media (hover: none) {
+  .btn-outline-secondary { 
+    /* Use these variables so that themes can set them to match their own button color */
+    --btn-outline-secondary-color: var(--bs-btn-color)
+    --btn-outline-secondary-bg: var(--bs-btn-bg)
+  }
+
+  .btn-outline-secondary:where(:not(.dropdown-toggle)):hover { /* leave hover on for dropdown buttons so they stay highlighted when clicked */
+    background-color: var(--btn-outline-secondary-bg);
+    color: var(--btn-outline-secondary-color);
+    text-decoration: none;
+  } 
+}} 
+
 .eval-line-above {
   fill: none;
   stroke: #ffab00;

--- a/assets/css/themes/gray.css
+++ b/assets/css/themes/gray.css
@@ -5,7 +5,11 @@
 cg-board {
   background-image: url('../images/board/gray.svg');
 }
-.chat-text,.nav-link,.btn-outline-secondary,.card-header,.card-footer {
+.btn-outline-secondary {
+  --btn-outline-secondary-color: lightgray; /* used to set hover color to the regular button color on mobile (effectively disabling hover for buttons on mobile) */
+  color: var(--btn-outline-secondary-color)
+}
+.chat-text,.nav-link,.card-header,.card-footer {
   color: lightgray;
 }
 .top-panel,.bottom-panel {


### PR DESCRIPTION
I don't like the way that buttons stay 'hovered' after clicking them on mobile. It especially looks bad for the Chat button, but also looks a bit weird for other buttons too. For example if you click on the Forward button and then start making moves on the board, it doesn't detect that you've clicked somewhere else and keeps the hover highlighting on the Forward button. 

I've come up with a little hack to turn hover off for buttons on devices that don't have a mouse. It required modifying the themes a bit too (the Gray theme). I just kept the hover state on the dropdown buttons, because Bootstrap seems to use that to show that the button has been dropped down or not. Take a look at tell me what you think?