### PR TITLE
Disable hover state for buttons on mobile (because it looks stupid)

### DIFF
--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -323,6 +323,15 @@ ul.list-striped > li {
   }
 }
 
+/* Turn hover state off for buttons on devices with no mouse (mobile) because it looks stupid */
+/* We achieve this by setting the hover color to match the normal button color */
+@media (hover: none) {
+  .btn-outline-secondary:hover { 
+    --bs-btn-hover-color: var(--bs-btn-color);
+    --bs-btn-hover-bg: var(--bs-btn-bg);
+  }
+}
+
 .eval-line-above {
   fill: none;
   stroke: #ffab00;

--- a/assets/css/themes/gray.css
+++ b/assets/css/themes/gray.css
@@ -5,7 +5,10 @@
 cg-board {
   background-image: url('../images/board/gray.svg');
 }
-.chat-text,.nav-link,.btn-outline-secondary,.card-header,.card-footer {
+.btn-outline-secondary {
+  --bs-btn-color: lightgray; /* Override bs variable rather than style directly so we can refer to it in sub-stles like :hover */
+}
+.chat-text,.nav-link,.card-header,.card-footer {
   color: lightgray;
 }
 .top-panel,.bottom-panel {


### PR DESCRIPTION
I don't like the way that buttons stay 'hovered' after clicking them on mobile. It especially looks bad for the Chat button, but also looks a bit weird for other buttons too. For example if you click on the Forward button and then start making moves on the board, it doesn't detect that you've clicked somewhere else and keeps the hover highlighting on the Forward button.

I've come up with a little hack to turn hover off for buttons on devices that don't have a mouse. It required modifying the themes a bit too (the Gray theme). Take a look at tell me what you think?