### PR TITLE
A Notification panel system

### DIFF
--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -75,11 +75,11 @@ html, body {
   text-decoration: none;
 }
 
-#chat-unread-bubble {
+.counter-bubble {
   fill: red;
 }
 
-#chat-unread-number {
+.counter-number {
   font-size: 8px;
   fill: white;
 }
@@ -390,3 +390,60 @@ ul.list-striped > li {
   margin: 0px;
   border-bottom: none;  
 }
+
+.notification-panel {
+  transition: none;
+  width: 100%;
+  position: relative;
+  z-index: 0;
+  background-color: white;
+  border-color: #DDDDDD;
+}
+
+#notifications.slide-up {
+  transition: opacity 0.8s ease, transform 0.8s ease;
+}
+
+.notification-panel.slide-down {
+  transition: opacity 0.8s ease, margin-top 0.8s ease, z-index 0s ease 0.8s;
+}
+
+.notification-panel.slide-sideways {
+  transition: opacity 0.8s ease, transform 0.8s ease;
+}
+
+.notification-panel.slide-up {
+  transition: opacity 0.8s ease, margin-top 0.8s ease;  
+}
+
+.notification .toast-header {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  background-color: white;
+}
+
+.notification .toast-body {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+#notifications-header {
+  background-color: ghostwhite;
+} 
+
+#notifications-header .toast-body {
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
+
+#notifications-close-icon {
+  color: #060600; 
+  font-size: 19px; 
+  transform: translate(-1.5px, -3.2px);
+}
+
+#notifications-footer .toast-body {
+  padding-top: 3px;
+  padding-bottom: 4px;
+}
+

--- a/play.html
+++ b/play.html
@@ -28,7 +28,25 @@
   <link rel="shortcut icon" href="assets/img/favicon.ico" type="image/x-icon">
 </head>
 <body>
-  <div class="feature3 p-0">
+  <div id="notifications" style="z-index: 2000; position: fixed; top: 0; right: 0; width: 100%">
+    <div class="toast notification-panel" data-bs-autohide="false" role="status" aria-live="polite" aria-atomic="true" id="notifications-header">
+      <div class="toast-body position-relative d-flex">
+        <span class="mx-auto">Notifications</span>
+        <button type="button" class="btn-close" style="background: transparent; position: absolute; right: 6px; top: 50%; transform: translateY(-50%);" aria-label="Hide">
+          <span id="notifications-close-icon" class="fa-solid fa-chevron-down" aria-hidden="false"></span>
+        </button>
+      </div>
+    </div>
+    <div class="toast notification-panel" data-bs-autohide="false" role="status" aria-live="polite" aria-atomic="true" id="notifications-footer">
+      <div class="toast-body">
+        <div class="d-flex">
+          <a class="me-auto" id="notifications-clear-all" style="cursor: pointer; text-decoration: none; font-style: italic">Clear all</a>
+          <a class="ms-auto" id="notifications-show-all" style="cursor: pointer; text-decoration: none; font-style: italic">Show all >></a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="feature3 p-0 position-relative">
     <div class="row justify-content-md-center m-0" id="col-group">
       <div class="card-group p-0">
         <div id="left-col" class="col-sm-12 col-md-3 col-lg-3 col-xl-3 align-self-center" style="min-width: 340px">
@@ -286,7 +304,7 @@
             </div>
           </div>
         </div>
-        <div id="mid-col" class="col-sm-12 col-md-9 col-lg-6 col-xl-6 align-self-center">
+        <div id="mid-col" class="col-sm-12 col-md-9 col-lg-6 col-xl-6 position-relative align-self-center">
           <div class="card bg-transparent" id="mid-card">
             <div class="top-panel card-header p-0">
               <div class="ps-2 pe-2 h-100 w-100 d-flex flex-wrap justify-content-between align-items-center status noselect" id="opponent-status">
@@ -317,7 +335,7 @@
             </div>
           </div>
         </div>
-        <div id="right-col" class="col align-self-center" style="min-width: 320px">
+        <div id="right-col" class="col position-relative align-self-center" style="min-width: 360px">
           <div class="card bg-transparent" id="right-card">
             <div class="top-panel card-header status" id="right-panel-header" style="visibility: hidden">
               <div id="user-dropdown" class="dropdown btn-toolbar my-auto me-auto" style="max-width: 50%">
@@ -363,11 +381,21 @@
                     <div class="dropdown-item disabled noselect" id="version"></div>
                   </div>
                 </div>
+                <span tabindex="0" data-bs-toggle="tooltip" data-bs-placement="left" title="No notifications">
+                  <button id="notifications-btn" style="position: relative" class="btn btn-outline-secondary btn-md" type="button" aria-label="Notifications" data-bs-toggle="button" disabled>
+                    <span id="notifications-icon" class="fa fa-bell" aria-hidden="false"></span>
+                    <svg id="notifications-bubble" class="counter-bubble h-100 w-100" style="display: none; position: absolute; top: 0; left: 0">
+                      <circle cx="50%" cy="50%" transform="translate(6, -6)" r="6" />
+                      <text id="notifications-number" class="counter-number" x="50%" y="50%" transform="translate(6, -5)" text-anchor="middle" alignment-baseline="middle"></text>
+                    </svg>
+                  </button>
+                  <span></span> <!-- This tricks bootstrap into allowing the outer <span> wrapper in a btn-toolbar (so we can have a tooltip on a disabled button) -->
+                </span>
                 <button id="chat-toggle-btn" style="position: relative" class="btn btn-outline-secondary btn-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-chat" aria-expanded="true" title="Show/Hide Chat" aria-controls="collapse-chat">
                   <span id="chat-toggle-icon" class="fa fa-comment" aria-hidden="false"></span>
-                  <svg id="chat-unread-bubble" class="h-100 w-100" style="display: none; position: absolute; top: 0; left: 0">
+                  <svg id="chat-unread-bubble" class="counter-bubble h-100 w-100" style="display: none; position: absolute; top: 0; left: 0">
                     <circle cx="50%" cy="50%" transform="translate(6, -6)" r="6" />
-                    <text id="chat-unread-number" x="50%" y="50%" transform="translate(6, -5)" text-anchor="middle" alignment-baseline="middle"></text>
+                    <text id="chat-unread-number" class="counter-number" x="50%" y="50%" transform="translate(6, -5)" text-anchor="middle" alignment-baseline="middle"></text>
                   </svg>
                 </button>
               </div>

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -5,7 +5,7 @@
 import Cookies from 'js-cookie';
 import { autoLink } from 'autolink-js';
 import { load as loadEmojis, parse as parseEmojis } from 'gh-emoji';
-import { scrollToBoard, isSmallWindow } from './index';
+import { notificationsToggle, scrollToBoard, isSmallWindow } from './index';
 
 // list of channels
 const channels = {
@@ -94,14 +94,12 @@ export class Chat {
   private emojisLoaded: boolean;
   private maximized: boolean;
   private autoscrollToggle: boolean;
-  private notificationsToggle: boolean;
   private timestampToggle: boolean;
   private unreadNum: number;
 
   constructor(user: string) {
     this.unreadNum = 0;
     this.autoscrollToggle = (Cookies.get('autoscroll') !== 'false');
-    this.notificationsToggle = (Cookies.get('notifications') !== 'false');
     this.timestampToggle = (Cookies.get('timestamp') !== 'false');
     // load emojis
     this.emojisLoaded = false;
@@ -141,19 +139,6 @@ export class Chat {
       $('#autoscroll-toggle').html('<span id="autoscroll-toggle-icon" class="' + iconClass +
         '" aria-hidden="false"></span>Auto-scroll ' + (this.autoscrollToggle ? 'ON' : 'OFF'));
       Cookies.set('autoscroll', String(this.autoscrollToggle), { expires: 365 })
-    });
-
-    if (!this.notificationsToggle) {
-      const iconClass = 'dropdown-icon fa fa-bell-slash';
-      $('#notifications-toggle').html('<span id="notifications-toggle-icon" class="' + iconClass +
-        '" aria-hidden="false"></span>Notifications OFF');
-    }
-    $('#notifications-toggle').on('click', (event) => {
-      this.notificationsToggle = !this.notificationsToggle;
-      const iconClass = 'dropdown-icon fa fa-bell' + (this.notificationsToggle ? '' : '-slash');
-      $('#notifications-toggle').html('<span id="notifications-toggle-icon" class="' + iconClass +
-        '" aria-hidden="false"></span>Notifications ' + (this.notificationsToggle ? 'ON' : 'OFF'));
-      Cookies.set('notifications', String(this.notificationsToggle), { expires: 365 })
     });
 
     const timestampIcon = '<span id="timestamp-toggle-icon" class="fa fa-clock-o dropdown-icon" aria-hidden="false"></span>';
@@ -325,7 +310,7 @@ export class Chat {
   }
 
   public newNotification(msg: string) {
-    if(!msg.startsWith('Notification:') || this.notificationsToggle) {
+    if(!msg.startsWith('Notification:') || notificationsToggle) {
       const currentTab = this.currentTab().toLowerCase().replace(/\s/g, '-');
       const tab = this.tabs[currentTab];
       msg = '<strong class="notification">' + msg + '</strong>';

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ let soundToggle: boolean = (Cookies.get('sound') !== 'false');
 let autoPromoteToggle: boolean = (Cookies.get('autopromote') === 'true');
 // toggle for showing Computer opponents in the lobby
 let lobbyShowComputersToggle: boolean = (Cookies.get('lobbyshowcomputers') === 'true');
+// toggle for automatically showing new slide-down notifications or notifications in chat channels
+export let notificationsToggle: boolean = (Cookies.get('notifications') !== 'false');
 
 let historyRequested = 0;
 let obsRequested = 0;
@@ -101,7 +103,7 @@ export function cleanup() {
   gameChangePending = false;
   removeSubvariationRequested = false;
   clearMatchRequests();
-
+  clearNotifications();
   cleanupGame();
 }
 
@@ -506,40 +508,347 @@ function showStatusMsg(msg: string) {
 }
 
 function showModal(type: string, title: string, msg: string, btnFailure: string[], btnSuccess: string[], progress = false, useSessionSend = true) {
+  var modalHtml = createModal(type, title, msg, btnFailure, btnSuccess, progress, useSessionSend);
+  var modal = $(modalHtml).appendTo($('#game-requests'));
+  modal.toast('show');
+}
+
+function createModal(type: string, title: string, msg: string, btnFailure: string[], btnSuccess: string[], progress = false, useSessionSend = true) { 
   const modalId = 'modal' + modalCounter++;
   let req = `
   <div id="` + modalId + `" class="toast" data-bs-autohide="false" role="status" aria-live="polite" aria-atomic="true">
-    <div class="toast-header"><strong class="me-auto">` + type + `</strong>
-    <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button></div>
-    <div class="toast-body"><div class="d-flex align-items-center">
-    <strong class="text-primary my-auto">` + title + ' ' + msg + '</strong>';
-
+    <div class="toast-header">
+      <strong class="header-text me-auto">` + type + `</strong>
+      <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
+    <div class="toast-body">
+      <div class="d-flex align-items-center">
+        <strong class="body-text text-primary my-auto">` + title + ' ' + msg + '</strong>';
+  
   if (progress) {
     req += '<div class="spinner-border ms-auto" role="status" aria-hidden="true"></div>';
   }
+  req += '</div>';
 
-  req += '</div><div class="mt-2 pt-2 border-top center">';
-
-  let successCmd = btnSuccess[0];
-  let failureCmd = btnFailure[0];
-  if(useSessionSend) {
-    successCmd = "sessionSend('" + btnSuccess[0] + "');";
-    failureCmd = "sessionSend('" + btnFailure[0] + "');";
+  if(btnSuccess !== undefined || btnFailure !== undefined) {
+    req += '<div class="mt-2 pt-2 border-top center">';
+    if (btnSuccess !== undefined && btnSuccess.length === 2) {
+      let successCmd = btnSuccess[0];
+      if(useSessionSend) 
+        successCmd = "sessionSend('" + btnSuccess[0] + "');";
+      req += '<button type="button" onclick="' + successCmd + `" class="button-success btn btn-sm btn-outline-success me-4" data-bs-dismiss="toast">
+          <span class="fa fa-check-circle-o" aria-hidden="false"></span> ` + btnSuccess[1] + '</button>';
+    }
+    if (btnFailure !== undefined && btnFailure.length === 2) {
+      let failureCmd = btnFailure[0];
+      if(useSessionSend) 
+        failureCmd = "sessionSend('" + btnFailure[0] + "');";  
+      req += '<button type="button" onclick="' + failureCmd + `" class="button-failure btn btn-sm btn-outline-danger" data-bs-dismiss="toast">
+          <span class="fa fa-times-circle-o" aria-hidden="false"></span> ` + btnFailure[1] + '</button>';
+    }
+    req += '</div>';
   }
 
-  if (btnSuccess !== undefined && btnSuccess.length === 2) {
-    req += '<button type="button" id="btn-success" onclick="' + successCmd + `" class="btn btn-sm btn-outline-success me-4" data-bs-dismiss="toast">
-        <span class="fa fa-check-circle-o" aria-hidden="false"></span> ` + btnSuccess[1] + '</button>';
+  req += '</div></div>';
+
+  return req;
+}
+
+function createNotification(type: string, title: string, msg: string, btnFailure: string[], btnSuccess: string[], progress = false, useSessionSend = true) {
+  var modalHtml = createModal(type, title, msg, btnFailure, btnSuccess, progress, useSessionSend);
+  var modal = $(modalHtml).insertBefore($('#notifications-footer')); 
+  modal.find('[data-bs-dismiss="toast"]').removeAttr('data-bs-dismiss');  
+  modal.on('click', 'button', (event) => {
+    removeNotification(modal);
+  });
+  modal.addClass('notification'); 
+  modal.addClass('notification-panel');
+  $('#notifications-btn').prop('disabled', false); 
+  $('#notifications-btn').parent().prop('title', 'Notifications');
+  createTooltip($('#notifications-btn').parent());
+
+  $('#notifications-number').text($('.notification:not([data-remove="true"])').length);
+  $('#notifications-bubble').show();
+  
+  if(notificationsToggle || $('#notifications-header').attr('data-show'))
+    showNotifications(modal);
+}
+
+function removeNotification(element: any) {
+  element.removeAttr('data-show');
+  element.attr('data-remove', 'true');
+
+  if(!$('.notification:not([data-remove="true"])').length) {
+    $('#notifications-btn').prop('disabled', true); 
+    $('#notifications-btn').parent().prop('title', 'No notifications');
+    createTooltip($('#notifications-btn').parent());
+    $('#notifications-bubble').hide();
+  }
+  $('#notifications-number').text($('.notification:not([data-remove="true"])').length);
+
+  if($('#notifications-header').attr('data-show') && !$('.notification[data-show="true"]').length) {
+    $('#notifications-header').removeAttr('data-show');
+    $('#notifications-header').toast('hide');
+    if($('#notifications-btn').hasClass('active'))
+      $('#notifications-btn').button('toggle');
+  }
+  if($('#notifications-footer').attr('data-show') && (!$('.notification[data-show="true"]').length || $('.notification:not([data-remove="true"])').length <= 1)) {
+    $('#notifications-footer').removeAttr('data-show');
+    $('#notifications-footer').toast('hide');
   }
 
-  if (btnFailure !== undefined && btnFailure.length === 2) {
-    req += '<button type="button" id="btn-failure" onclick="' + failureCmd + `" class="btn btn-sm btn-outline-danger" data-bs-dismiss="toast">
-        <span class="fa fa-times-circle-o" aria-hidden="false"></span> ` + btnFailure[1] + '</button>';
+  // Remove notification half way through its slide, because remove() takes a while. 
+  setTimeout(() => element.remove(), 400);
+
+  var transformMatrix = element.css('transform');
+  var matrix = transformMatrix.replace(/[^0-9\-.,]/g, '').split(',');
+  var x = matrix[12] || matrix[4]; // translate x
+  slideNotification(element, (x < 0 ? 'left' : 'right'));
+}
+
+function showNotifications(modals: any) {
+  // If not all notifications are displayed, add a 'Show All' button to the footer
+  var allShown = true;
+  $('.notification').each((index, element) => {
+    if(!$(element).attr('data-show') && !$(element).attr('data-remove') && modals.index($(element)) === -1) 
+      allShown = false;
+  });
+  if(allShown) 
+    $('#notifications-show-all').hide();
+  else
+    $('#notifications-show-all').show(); 
+
+  if(!$('#notifications-header').attr('data-show')) {
+    $('#notifications-header').attr('data-show', 'true');
+    $('#notifications-header').toast('show');
+    slideNotification($('#notifications-header'), 'down');
   }
 
-  req += '</div></div></div>';
-  $('#game-requests').append(req);
-  $('#' + modalId).toast('show');
+  modals.each((index, element) => {
+    if(!$(element).attr('data-show')) {
+      $(element).attr('data-show', 'true');
+      $(element).toast('show');
+      slideNotification($(element), 'down');
+    }
+  });
+
+  if($('.notification:not([data-remove="true"])').length > 1 && !$('#notifications-footer').attr('data-show')) {
+    $('#notifications-footer').attr('data-show', 'true');
+    $('#notifications-footer').toast('show');
+    slideNotification($('#notifications-footer'), 'down');
+  }
+}
+
+/* Perform slide transition (animation) on Notification panel */
+function slideNotification(element: any, direction: 'down' | 'up' | 'left' | 'right') {
+  if(direction === 'down') {
+    // Set initial state before transition
+    resetSlide(element);
+    $('#notifications').css('opacity', '');
+    $('#notifications').css('transform', '');
+    $('#notifications').show();
+    element.css('margin-top', -element[0].getBoundingClientRect().height);
+    element.css('z-index', '-1');
+    element.css('opacity', '0');
+    // Trigger transition after toast is shown
+    element.one('shown.bs.toast', (event) => {
+      // Add transition (animation)
+      $(event.target).addClass('slide-down'); 
+      $(event.target).css('margin-top', '');
+      $(event.target).css('z-index', '');
+      $(event.target).css('opacity', '');
+      $(event.target).one('transitionend', (event) => {
+        $(event.target).removeClass('slide-down');
+        $(event.target).height($(event.target).height()); // Fixes a layout glitch from the transition
+      });
+    });
+  }
+  else if(direction === 'up') {
+    // Set initial state before transition
+    element.addClass('slide-up'); 
+    element.css('margin-top', -element[0].getBoundingClientRect().height);
+    element.css('opacity', '0');
+    element.one('transitionend', (event) => {
+      if(!$(event.target).attr('data-show')) 
+        $(event.target).toast('hide');
+      $(event.target).removeClass('slide-up');
+      $(event.target).css('opacity', '');
+      $(event.target).css('margin-top', '');
+    });
+  }
+  else if(direction === 'left' || direction === 'right') {
+    // Set initial state before transition
+    element.css('z-index', '-1');
+    element.addClass('slide-sideways'); 
+    element.css('transform', 'translateX(' + (direction === 'left' ? '-' : '') + '100%)');
+    element.css('opacity', '0');
+    element.one('transitionend', (event) => {
+      $(event.target).removeClass('slide-sideways');
+      $(event.target).toast('hide');
+      $(event.target).css('z-index', ''); 
+      $(event.target).css('transform', '');
+      $(event.target).css('opacity', '');
+    });
+  }
+}
+
+function slideAllNotifications() {
+  $('#notifications').children().each((index, element) => resetSlide($(element)));
+  $('#notifications').addClass('slide-up'); 
+  $('#notifications').css('opacity', 0);
+  $('#notifications').css('transform', 'translateY(-100%)');
+  $('#notifications').one('transitionend', (event) => {
+    $(event.currentTarget).removeClass('slide-up');
+    var shown = false;
+    $(event.currentTarget).children().each((index, element) => {
+      if(!$(element).attr('data-show')) 
+        $(element).toast('hide');
+      else
+        shown = true;
+    });
+    if(!shown) 
+      $('#notifications').hide();
+    $(event.currentTarget).css('transform', '');
+    $(event.currentTarget).css('opacity', '');
+  });
+}
+
+function resetSlide(element: any) {
+  element.removeClass('slide-sideways'); 
+  element.removeClass('slide-down'); 
+  element.removeClass('slide-up'); 
+  element.css('z-index', ''); 
+  element.css('transform', '');
+  element.css('opacity', '');
+  element.css('margin-top', '');
+}
+
+$('#notifications')[0].addEventListener('mousedown', notificationMouseDown);
+$('#notifications')[0].addEventListener('touchstart', notificationMouseDown, {passive: false});
+function notificationMouseDown(e) {
+  if(!$(e.target).is('div'))
+    return;
+
+  if($(':focus').length > 0) 
+      $(':focus').trigger('blur');
+  
+  if(window.getSelection) 
+    window.getSelection().removeAllRanges();
+
+  $('#notifications').css('--dragX', 0);
+  $('#notifications').css('--dragY', 0);
+  $('#notifications').css('--opacityY', 1);   
+  $('#notifications').css('--opacityX', 1);   
+
+  var modal = $(e.target).closest('.toast');
+  modal.css('transition', 'none');
+
+  // Prevent mouse pointer events on webpage while dragging panel
+  jQuery('<div/>', {
+    id: 'mouse-capture-layer',
+    css: {'z-index': '9999', 
+      'top': '0',
+      'left': '0',
+      'position': 'fixed',
+      'height': '100%',
+      'width': '100%' 
+    }
+  }).appendTo('body');
+
+  var swipeStart = getTouchClickCoordinates(e);
+  var swipeLocked = '';
+  const mouseMoveHandler = (e) => {   
+    var mouse = getTouchClickCoordinates(e);
+    if(swipeLocked) {
+      var xMax = $('#notifications').outerWidth(true);
+      var yMax = $('#notifications').outerHeight(true);
+      var xOffset = Math.min(xMax, Math.max(-xMax, mouse.x - swipeStart.x));
+      var yOffset = Math.min(0, mouse.y - swipeStart.y);
+      $('#notifications').css('--dragX', xOffset + 'px');
+      $('#notifications').css('--dragY', yOffset + 'px');
+      $('#notifications').css('--opacityY', (yMax - Math.abs(yOffset)) / yMax);   
+      $('#notifications').css('--opacityX', (xMax - Math.abs(xOffset)) / xMax);   
+    }
+    else {
+      if(swipeStart.y - mouse.y > 20 && Math.abs(swipeStart.y - mouse.y) > Math.abs(swipeStart.x - mouse.x)) {
+        // Perform vertical swipe
+        swipeStart = mouse;
+        swipeLocked = 'vertical';
+        $('#notifications').css('transform', 'translateY(var(--dragY))');
+        $('#notifications').css('opacity', 'var(--opacityY)');
+      }
+      else if(modal.hasClass('notification') && Math.abs(swipeStart.x - mouse.x) > 20 && Math.abs(swipeStart.x - mouse.x) > Math.abs(swipeStart.y - mouse.y)) {
+        // Perform horizontal swipe
+        swipeStart = mouse;
+        swipeLocked = 'horizontal';
+        modal.css('transform', 'translateX(var(--dragX))');
+        modal.css('opacity', 'var(--opacityX)');
+      }
+    }
+  };
+  $(document).on('mousemove touchmove', mouseMoveHandler);
+
+  $(document).one('mouseup touchend touchcancel', (e) => {
+    var mouse = getTouchClickCoordinates(e);
+    $('#mouse-capture-layer').remove();
+    $(document).off('mousemove touchmove', mouseMoveHandler);
+    if(swipeLocked === 'vertical') {
+      if(swipeStart.y - mouse.y > 30 && e.type !== 'touchcancel')
+        hideAllNotifications();
+      else {
+        $('#notifications').css('transform', '');
+        $('#notifications').css('opacity', '');
+      }
+    }
+    else if(swipeLocked === 'horizontal') {
+      if(Math.abs(mouse.x - swipeStart.x) > 50 && e.type !== 'touchcancel')
+        removeNotification(modal);
+      else {
+        modal.css('transform', '');
+        modal.css('opacity', '');
+      }
+    }
+    swipeLocked = '';
+    swipeStart = null;
+    modal.css('transition', '');
+  });
+
+  e.preventDefault();
+}
+
+function getTouchClickCoordinates(event: any) {
+  event = (event.originalEvent || event);
+  if(event.type == 'touchstart' || event.type == 'touchmove' || event.type == 'touchend' || event.type == 'touchcancel') {
+      var touch = event.touches[0] || event.changedTouches[0];
+      var x = touch.pageX;
+      var y = touch.pageY;
+  } else if (event.type == 'mousedown' || event.type == 'mouseup' || event.type == 'mousemove' || event.type == 'mouseover' || event.type=='mouseout' || event.type=='mouseenter' || event.type=='mouseleave') {
+      var x = event.clientX;
+      var y = event.clientY;
+  }
+  return {x, y};
+}
+
+function showAllNotifications() {
+  showNotifications($('.notification:not([data-show="true"])'));
+}
+
+function hideAllNotifications() {
+  $('#notifications').children('[data-show="true"]').each((index, element) => {
+    $(element).removeAttr('data-show'); 
+  });
+  if($('#notifications-btn').hasClass('active'))
+    $('#notifications-btn').button('toggle');
+  slideAllNotifications();
+}
+
+function clearNotifications() {
+  $('.notification').removeAttr('data-show'); 
+  var delay = 0;
+  $('.notification.show').each((index, element) => {
+    setTimeout(() => removeNotification($(element)), delay);
+    delay += 100;
+  });
 }
 
 // Check if square is under attack. We can remove this after upgrading to latest version of chess.js, 
@@ -897,6 +1206,7 @@ function messageHandler(data) {
         session.send('set interface www.freechess.club');
         session.send('iset defprompt 1'); // Force default prompt. Used for splitting up messages
         session.send('iset nowrap 1'); // Stop chat messages wrapping which was causing spaces to get removed erroneously
+        session.send('iset pendinfo 1'); // Receive detailed match request info (both that we send and receive)
         session.send('=ch');
         channelListRequested = true;
         session.send('=computer'); // get Computers list, to augment names in Observe panel
@@ -1239,7 +1549,6 @@ function messageHandler(data) {
               if(!matchRequested) {
                 session.send('iset seekinfo 0');
                 session.send('iset showownseek 0');  
-                session.send('iset pendinfo 0');
               }
             }
 
@@ -1307,7 +1616,6 @@ function messageHandler(data) {
         if(!matchRequested) {
           session.send('iset seekinfo 0');
           session.send('iset showownseek 0');
-          session.send('iset pendinfo 0');
         }
         if(newRequest) {
           clearTimeout(showMatchTimer);
@@ -1436,15 +1744,48 @@ function messageHandler(data) {
         return;
       }
 
-      match = msg.match(
-        /Challenge: (\w+) \(([\d\+\-\s]{4})\) (\[(?:white|black)\] )?(\w+) \(([\d\+\-\s]{4})\)\s((?:.+))You can "accept" or "decline", or propose different parameters./ms);
-      if (match != null && match.length > 4) {
-        const [opponentName, opponentRating] = (match[1] === session.getUser()) ?
-          match.slice(4, 6) : match.slice(1, 3);
-        showModal('Match Request', opponentName + '(' + opponentRating + ')' + (match[3] ? ' ' + match[3] : ''),
-          match[6], ['decline', 'Decline'], ['accept', 'Accept']);
+      // Match request received from another player
+      match = msg.match(/^\<pf\> (\d+) \S+ \S+ p=(\S+) (\S+)(?: (\[(?:black|white)\]))? \S+ \S+ (.+)/m); 
+      if(match) {
+        var id = match[1];
+        var opponentName = match[2];
+        var opponentRating = match[3];
+        var color = match[4];
+        var details = match[5];
+
+        var bodyTitle = opponentName + opponentRating + (color ? ' ' + color : '');
+        var found = false;
+        $('.notification').each((index, element) => {
+          var headerTextElement = $(element).find('.header-text');
+          var bodyTextElement = $(element).find('.body-text');
+          if(headerTextElement.text() === 'Match Request' && bodyTextElement.text().startsWith(opponentName + '(')) {
+            bodyTextElement.text(bodyTitle + ' ' + details);
+            var btnSuccess = $(element).find('.button-success');
+            var btnFailure = $(element).find('.button-failure');
+            btnSuccess.attr('onclick', `sessionSend('accept ` + id + `');`);
+            btnFailure.attr('onclick', `sessionSend('decline ` + id + `');`);
+            found = true;
+          }
+        });
+        if(!found)
+          createNotification('Match Request', bodyTitle, details, ['decline ' + id, 'Decline'], ['accept ' + id, 'Accept']);
         return;
       }
+      if(/^Challenge:/m.test(msg)) // Ignore challenge messages. Using <pf> instead
+        return;
+
+      match = msg.match(/^(\w+) withdraws the match offer\./m);
+      if (match != null && match.length > 1) {
+        $('.notification').each((index, element) => {
+          var headerTextElement = $(element).find('.header-text');
+          var bodyTextElement = $(element).find('.body-text');
+          if(headerTextElement.text() === 'Match Request' && bodyTextElement.text().startsWith(match[1] + '('))
+            removeNotification($(element));
+        });
+        return;
+      }
+      if(/^\<pr\>/m.test(msg)) // Ignore <pr> pendinfo messages (match request removed) 
+        return;
 
       match = msg.match(/(\w+) would like to abort the game; type "abort" to accept./);
       if (match != null && match.length > 1) {
@@ -1547,7 +1888,7 @@ function messageHandler(data) {
         msg === 'nowrap set.' ||
         msg === 'startpos set.' || msg === 'startpos unset.' ||
         msg === 'showownseek set.' || msg === 'showownseek unset.' ||
-        msg === 'pendinfo set.' || msg === 'pendinfo unset.' ||
+        msg === 'pendinfo set.' || 
         msg.startsWith('No one is observing game ') 
       ) {
         return;
@@ -1937,7 +2278,7 @@ $('#collapse-history').on('show.bs.collapse', (event) => {
   activeTab.tab('show');
 });
 
-$('#pills-tab button').on('click', (event) => {
+$('#pills-tab button').on('click', function(event) {
   activeTab = $(this);
   $('#collapse-history').collapse('show');
   scrollToTop();
@@ -2020,16 +2361,13 @@ function onDeviceReady() {
 
   $('#opponent-time').text('00:00');
   $('#player-time').text('00:00');
-
-  prevWindowWidth = $(window).innerWidth();
   
   if(isSmallWindow()) {
-    useMobileLayout();
     $('#collapse-chat').collapse('hide');
     $('#collapse-history').collapse('hide');
   }
   else {
-    configureTooltips();
+    createTooltips();
     $('#pills-play-tab').tab('show');
     $('#collapse-history').removeClass('collapse-init');
     $('#collapse-chat').removeClass('collapse-init');
@@ -2042,9 +2380,9 @@ function onDeviceReady() {
   selectOnFocus($('#observe-username'));
   selectOnFocus($('#examine-username'));
 
-  setPanelSizes();
+  prevWindowWidth = NaN;
+  $(window).trigger('resize');
 
-  // Wait for panels to resize
   game.role = Role.NONE;
   game.category = 'untimed';
   game.history = new History(new Chess().fen(), board);
@@ -2064,26 +2402,32 @@ function onDeviceReady() {
 // Enable tooltips. 
 // Allow different tooltip placements for mobile vs desktop display.
 // Make tooltips stay after click/focus on mobile, but only when hovering on desktop.
-function configureTooltips() {
-  $('[data-bs-toggle="tooltip"]').each(function(index, element) {   
-    var trigger = $(element);
-    var windowWidth = $(window).width();
+function createTooltip(element: any) {
+  var windowWidth = $(window).width();
 
-    var sm = trigger.attr('data-bs-placement-sm');
-    var md = trigger.attr('data-bs-placement-md');
-    var lg = trigger.attr('data-bs-placement-lg');
-    var xl = trigger.attr('data-bs-placement-xl');
-    var general = trigger.attr('data-bs-placement');
+  var sm = element.attr('data-bs-placement-sm');
+  var md = element.attr('data-bs-placement-md');
+  var lg = element.attr('data-bs-placement-lg');
+  var xl = element.attr('data-bs-placement-xl');
+  var general = element.attr('data-bs-placement');
 
-    var placement = (windowWidth >= 1200 ? xl : undefined) ||
-        (windowWidth >= 992 ? lg : undefined) ||
-        (windowWidth >= 768 ? md : undefined) ||
-        sm || general || "top";
+  var placement = (windowWidth >= 1200 ? xl : undefined) ||
+      (windowWidth >= 992 ? lg : undefined) ||
+      (windowWidth >= 768 ? md : undefined) ||
+      sm || general || "top";
 
-    trigger.tooltip('dispose').tooltip({
-      placement: placement as "left" | "top" | "bottom" | "right" | "auto",
-      trigger: (isSmallWindow() ? 'hover focus' : 'hover'), // Tooltips stay visible after element is clicked on mobile, but only when hovering on desktop 
-    });
+  var newTitle = element.prop('title');
+
+  element.tooltip('dispose').tooltip({
+    placement: placement as "left" | "top" | "bottom" | "right" | "auto",
+    trigger: (isSmallWindow() ? 'hover focus' : 'hover'), // Tooltips stay visible after element is clicked on mobile, but only when hovering on desktop 
+    ...newTitle && {title: newTitle}, // Only set title if it's defined
+  });
+}
+
+function createTooltips() {
+  $('[data-bs-toggle="tooltip"]').each(function(index, element) {  
+    createTooltip($(element));
   });
 }
 
@@ -2124,7 +2468,7 @@ function useMobileLayout() {
   $('#stop-examining').appendTo($('#viewing-game-buttons').last());
   $('#viewing-games-buttons:visible:last').addClass('me-0'); // This is so visible buttons in the btn-toolbar center properly
   hideCloseGamePanel();
-  configureTooltips();
+  createTooltips();
 }
 
 function useDesktopLayout() {
@@ -2134,7 +2478,7 @@ function useDesktopLayout() {
   $('#stop-examining').appendTo($('#close-game-panel').last());
   if(game.isObserving() || game.isExamining())
     showCloseGamePanel();
-  configureTooltips();
+  createTooltips();
 }
 
 function swapLeftRightPanelHeaders() {
@@ -2166,6 +2510,8 @@ function setPanelSizes() {
 
   // Make sure the board is smaller than the window height and also leaves room for the other columns' min-widths
   if(!isSmallWindow()) {
+    $('#mid-col').width(0);
+
     if($(window).innerWidth() < 992) // display 2 columns on md (medium) display
       var boardMaxWidth = $('#col-group').innerWidth() - $('#left-col').outerWidth();
     else
@@ -2174,7 +2520,7 @@ function setPanelSizes() {
     var cardBorderHeight = $('#mid-card').outerHeight() - $('#mid-card').height();
     var boardMaxHeight = $(window).height() - $('#player-status').outerHeight()
         - $('#opponent-status').outerHeight() - cardBorderHeight;
-
+    
     $('#mid-col').width(Math.min(boardMaxWidth, boardMaxHeight) - 0.1); 
   }
   else 
@@ -2238,6 +2584,14 @@ function setPanelSizes() {
     else
       $('#right-panel').height(boardHeight - rightPanelBorder - siblingsHeight);
   }
+
+  // Adjust Notifications drop-down width
+  if(isSmallWindow() && !isSmallWindow(prevWindowWidth)) 
+    $('#notifications').css('width', '100%');
+  else if(isMediumWindow() && !isMediumWindow(prevWindowWidth)) 
+    $('#notifications').css('width', '50%');
+  else if(isLargeWindow()) 
+    $('#notifications').width($(document).outerWidth(true) - $('#left-col').outerWidth(true) - $('#mid-col').outerWidth(true));
 }
 
 $(document).ready(() => {
@@ -2251,6 +2605,25 @@ $(document).ready(() => {
 $(window).on('load', function() {
   $('#left-panel-header').css('visibility', 'visible');
   $('#right-panel-header').css('visibility', 'visible');
+});
+
+$('#notifications-header .btn-close').on('click', (event) => {
+  hideAllNotifications();
+});
+
+$('#notifications-show-all').on('click', (event) => {
+  showAllNotifications();
+});
+
+$('#notifications-clear-all').on('click', (event) => {
+  clearNotifications();
+});
+
+$('#notifications-btn').on('click', function(event) {
+  if($(this).hasClass('active')) 
+    showAllNotifications();
+  else 
+    hideAllNotifications();
 });
 
 $('#resign').on('click', (event) => {
@@ -2339,8 +2712,6 @@ function getGame(min: number, sec: number) {
     session.send('iset showownseek 1');
     session.send('iset seekinfo 1');
   }
-  else
-    session.send('iset pendinfo 1');
   session.send(cmd + ' ' + min + ' ' + sec);
 }
 (window as any).getGame = getGame;
@@ -2349,7 +2720,6 @@ function clearMatchRequests() {
   if(session && session.isConnected()) {
     session.send('iset seekinfo 0');
     session.send('iset showownseek 0');
-    session.send('iset pendinfo 0');
   }
   matchRequested = 0;
   matchRequests.clear();
@@ -2357,10 +2727,9 @@ function clearMatchRequests() {
 }
 
 $('#input-text').on('focus', () => {
-  $('#board').on('touchstart', () => {
+  $('#board')[0].addEventListener('touchstart', (event) => {
     $('#input-text').trigger('blur');
-    $('#board').off('touchstart');
-  });
+  }, {once: true, passive: true}); // Got sick of Google Chrome complaining about passive event listeners
 });
 
 $('#new-game').on('click', (event) => {
@@ -2527,18 +2896,31 @@ $(document).on('keydown', (e) => {
     forward();
 });
 
-if (!soundToggle) {
-  const iconClass = 'dropdown-icon fa fa-volume-off';
-  $('#sound-toggle').html('<span id="sound-toggle-icon" class="' + iconClass +
-    '" aria-hidden="false"></span>Sounds OFF');
-}
+updateDropdownSound();
 $('#sound-toggle').on('click', (event) => {
   soundToggle = !soundToggle;
+  updateDropdownSound();
+  Cookies.set('sound', String(soundToggle), { expires: 365 })
+});
+function updateDropdownSound() {
   const iconClass = 'dropdown-icon fa fa-volume-' + (soundToggle ? 'up' : 'off');
   $('#sound-toggle').html('<span id="sound-toggle-icon" class="' + iconClass +
     '" aria-hidden="false"></span>Sounds ' + (soundToggle ? 'ON' : 'OFF'));
-  Cookies.set('sound', String(soundToggle), { expires: 365 })
+}
+
+updateDropdownNotifications();
+$('#notifications-toggle').on('click', (event) => {
+  notificationsToggle = !notificationsToggle;
+  updateDropdownNotifications();
+  Cookies.set('notifications', String(notificationsToggle), { expires: 365 })
 });
+function updateDropdownNotifications() {
+  const iconClass = 'dropdown-icon fa fa-bell' + (notificationsToggle ? '' : '-slash');
+  $('#notifications-toggle').html('<span id="notifications-toggle-icon" class="' + iconClass +
+    '" aria-hidden="false"></span>Notifications ' + (notificationsToggle ? 'ON' : 'OFF'));
+  $('#notifications-icon').removeClass(notificationsToggle ? 'fa-bell-slash' : 'fa-bell');
+  $('#notifications-icon').addClass(notificationsToggle ? 'fa-bell' : 'fa-bell-slash');
+}
 
 updateDropdownAutoPromote();
 $('#autopromote-toggle').on('click', (event) => {
@@ -2626,18 +3008,33 @@ $('#login-as-guest').on('click', (event) => {
   }
 });
 
-export function isSmallWindow() {
-  return window.innerWidth < 768;
+export function isSmallWindow(size?: number) {
+  if(size === undefined)
+    size = window.innerWidth;
+  return size < 768;
+}
+
+export function isMediumWindow(size?: number) {
+  if(size === undefined)
+    size = window.innerWidth;
+  return size < 992 && size >= 768;
+}
+
+export function isLargeWindow(size?: number) {
+  if(size === undefined)
+    size = window.innerWidth;
+  return size >= 992;
 }
 
 $(window).on('resize', () => {
-  if(isSmallWindow() && prevWindowWidth >= 768)
+  if(isSmallWindow() && !isSmallWindow(prevWindowWidth))
     useMobileLayout();
-  else if(!isSmallWindow() && prevWindowWidth < 768)
+  else if(!isSmallWindow() && isSmallWindow(prevWindowWidth))
     useDesktopLayout();
 
-  prevWindowWidth = window.innerWidth;
   setPanelSizes();
+
+  prevWindowWidth = window.innerWidth;
 
   // Put other resizing stuff in here. Need time for columns to resize properly, 
   // i.e. scrollbar takes a while to appear/disappear after resizing board
@@ -2688,7 +3085,6 @@ function showTab(tab: any) {
 
 (window as any).acceptSeek = (id: number) => {
   matchRequested++;
-  session.send('iset pendinfo 1'); // in case seek was set to 'manual', display the resulting match request in the pairing pane
   session.send('play ' + id);
 };
 
@@ -2843,7 +3239,9 @@ $(document).on('shown.bs.tab', 'button[data-bs-target="#pills-lobby"]', (e) => {
 });
 
 function initLobbyPane() {
-  if(game.isExamining() || game.isPlaying() || !session || !session.isConnected()) {
+  if(!session || !session.isConnected())
+    $('#lobby').hide();
+  else if(game.isExamining() || game.isPlaying()) {
     if(game.isExamining())
       $('#lobby-pane-status').text('Can\'t enter lobby while examining a game.');
     else


### PR DESCRIPTION
Draft: Just need to do a little more on this. Can't currently accept/decline match offers when there is more than one. Should switch to using iset pendinfo 1 all the time. 

* Notifications slide down from the top of the screen.
* Mobile swipe/mouse drag gestures to hide (swipe up) or remove (swipe left/right).
* Hidden notifications can be shown using the Notifications button next to Settings. Notification button has a bubble which displays number of notifications.
* Footer appears when there are multiple notifications with 'Clear all' button to quickly remove all notifications and 'Show all' button to show hidden ones
* Can be muted in the Settings, in which case new Notifications won't automatically slide down.
* Currently only used for Match Requests. When a match request is withdrawn or changed the notifications are removed/updated.