### PR TITLE
Fix ambiguous move error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -471,15 +471,16 @@ export function movePiece(source: any, target: any, metadata: any) {
 
     chess.load(fen);
 
+    var promotion = (promotePiece ? '=' + promotePiece : '');
     if (game.isPlaying() && game.chess.turn() !== game.color)
-      session.send(move.san);
+      session.send(move.from + '-' + move.to + promotion);
    
     if(game.isExamining()) {
       var nextMove = game.history.get(game.history.next());
       if(nextMove && !nextMove.subvariation && !game.history.scratch() && fen === nextMove.fen) 
         session.send('for');
       else
-        session.send(move.san);
+        session.send(move.from + '-' + move.to + promotion);
     }
   }
 


### PR DESCRIPTION
#71 made some tweaks to support variants and changed to sending moves to the server in algebraic notation.
This mostly work fine but it also leads to ambiguous moves in certain situations where more than one piece can validly move to a square.

FICS documents the cases when this can happen [here](https://www.freechess.org/Help/HelpFiles/intro_moving.html).

> ***Special Case***  AMBIGUOUS MOVES:  It is possible, in certain board
positions, for both a pawn on the b-file and a bishop to make a capture on the
same square.  Unfortunately, the server may confuse a 'b' meaning the pawn on
the b-file with a 'b' meaning a bishop.  In this case, the move 'bc6' may be
ambiguous, and the server will not know which piece to move, the b-pawn or the
bishop.  If this ever happens to you, enter the pawn capture as 'pxc6'.
  Another case of an ambiguous move concerns which piece you want to capture. 
For example, does Rxb4 mean 'rook capture on square b4' -or- 'rook capture
bishop on rank 4'?  To avoid this problem, you can denote the capture as a
simple move from one square to another (such as Rb4) or give the full
information for a capture (such as RxPb4).

The most common scenario in which this was observed was actually the following (which is in fact not really ambiguous but the server wrongly treats it so!):
<img width="300" alt="image" src="https://github.com/freechessclub/freechessclub-app/assets/79025846/921e1d66-2f63-4c17-9e42-13183eedb7c0">
Here bxc6 and Bxc6 are both treated as ambiguous because "lower and upper
case letters are the same for the chess server".

This PR reverts back to using the older computer notation (src-target).

@dhirallin Is reverting back this change an issue for variants?