### PR TITLE
Color ratedunrated options

### DIFF
--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -53,6 +53,10 @@ html, body {
   text-align: center;
 }
 
+#left-panel {
+  height: 460px;
+}
+
 #left-panel-bottom {
   height: 192px;
   width: 100%;

--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -487,3 +487,7 @@ html, body {
   padding-bottom: 1px;
   background-color: rgba(0, 0, 0, 0.05);
 }
+
+.modal {
+  --bs-modal-color: var(--fg-color);
+}

--- a/assets/css/themes/gray.css
+++ b/assets/css/themes/gray.css
@@ -188,7 +188,8 @@ cg-board {
   --bs-toast-header-bg: #333333;
   --bs-toast-header-color: #B4C9D2;
 }
-.toast .btn-close {
+
+.btn-close {
   filter: invert(1) grayscale(100%) brightness(200%);
 }
 

--- a/play.html
+++ b/play.html
@@ -265,7 +265,7 @@
                   <div class="tab-content flex-grow-1" style="min-height: 0">
                     <div class="tab-pane fade show active p-1 h-100" id="status-panel" role="tabpanel" aria-labelledby="status-panel">
                       <div class="d-flex flex-column overflow-auto center h-100">
-                        <div class="px-2 w-100">
+                        <div class="px-2 w-100 h-100">
                           <div id="game-status" class="center py-1"></div>
                           <div id="opening-name" class="center py-1 border-top" style="display: none"></div>
                           <div id="game-watchers" class="center pt-2 pb-1 border-top"></div>

--- a/play.html
+++ b/play.html
@@ -140,7 +140,7 @@
                                   <button type="button" class="w-100 btn btn-outline-secondary btn-md" href="#" onclick="getGame(20,0);">20 min</button>
                                 </div>
                                 <a href="#" class="btn btn-outline-secondary btn-md disabled p-0" role="button" aria-disabled="true"><span class="me-2 fa fa-clock-o" aria-hidden="false"></span>Custom</a>
-                                <form id="custom-control">
+                                <form id="custom-control" class="w-100">
                                   <div class="input-group">
                                     <input type="text" class="form-control text-center" id="custom-control-min" value="0" maxlength="3">
                                     <span class="input-group-text"> min </span>
@@ -151,36 +151,49 @@
                                     </span>
                                   </div>
                                 </form>
-                                <div class="btn-group dropdown position-static" role="group" aria-label="Study">
-                                  <button class="btn btn-outline-secondary dropdown-toggle" id="variants-button" type="button" data-bs-toggle="dropdown" aria-expanded="false">Variants</button>
-                                  <ul class="dropdown-menu" id="variants-menu">
-                                    <li><a class="dropdown-item" href="#" onclick="setNewGameVariant('Standard', '');">Standard</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="setNewGameVariant('Chess960', 'wild fr');">Chess960</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="setNewGameVariant('Bughouse', 'bughouse');">Bughouse (4 player)</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="setNewGameVariant('Crazyhouse', 'crazyhouse');">Crazyhouse</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="setNewGameVariant('Losers', 'losers');">Losers</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="setNewGameVariant('Wild 0', 'wild 0');">Wild 0</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="setNewGameVariant('Wild 1', 'wild 1');">Wild 1</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="setNewGameVariant('Wild 2', 'wild 2');">Wild 2</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="setNewGameVariant('Wild 3', 'wild 3');">Wild 3</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="setNewGameVariant('Wild 4', 'wild 4');">Wild 4</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="setNewGameVariant('Wild 5', 'wild 5');">Wild 5</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="setNewGameVariant('Wild 8', 'wild 8');">Wild 8</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="setNewGameVariant('Wild 8a', 'wild 8a');">Wild 8a</a></li>
+                                <div class="btn-group dropdown position-static" role="group" aria-label="Custom-2">  
+                                  <button class="btn btn-outline-secondary dropdown-toggle w-100" id="player-color-button" type="button" data-bs-toggle="dropdown" aria-expanded="false">Any color</button>
+                                  <ul class="dropdown-menu" id="player-color-menu">
+                                    <li><a class="dropdown-item" onclick="setNewGameColor('Any color');">Any color</a></li>
+                                    <li><a class="dropdown-item" onclick="setNewGameColor('White');">White</a></li>
+                                    <li><a class="dropdown-item" onclick="setNewGameColor('Black');">Black</a></li>
                                   </ul>
+                                  <button class="btn btn-outline-secondary dropdown-toggle w-100" id="rated-unrated-button" type="button" data-bs-toggle="dropdown" aria-expanded="false">Unrated</button>
+                                  <ul class="dropdown-menu" id="rated-unrated-menu">
+                                    <li><a class="dropdown-item" onclick="setNewGameRated('Rated');">Rated</a></li>
+                                    <li><a class="dropdown-item" onclick="setNewGameRated('Unrated');">Unrated</a></li>
+                                  </ul>
+                                  <button class="btn btn-outline-secondary dropdown-toggle w-100" id="variants-button" type="button" data-bs-toggle="dropdown" aria-expanded="false">Variants</button>
+                                  <ul class="dropdown-menu" id="variants-menu">
+                                    <li><a class="dropdown-item" onclick="setNewGameVariant('Standard', '');">Standard</a></li>
+                                    <li><a class="dropdown-item" onclick="setNewGameVariant('Chess960', 'wild fr');">Chess960</a></li>
+                                    <li><a class="dropdown-item" onclick="setNewGameVariant('Bughouse', 'bughouse');">Bughouse (4 player)</a></li>
+                                    <li><a class="dropdown-item" onclick="setNewGameVariant('Crazyhouse', 'crazyhouse');">Crazyhouse</a></li>
+                                    <li><a class="dropdown-item" onclick="setNewGameVariant('Losers', 'losers');">Losers</a></li>
+                                    <li><a class="dropdown-item" onclick="setNewGameVariant('Wild 0', 'wild 0');">Wild 0</a></li>
+                                    <li><a class="dropdown-item" onclick="setNewGameVariant('Wild 1', 'wild 1');">Wild 1</a></li>
+                                    <li><a class="dropdown-item" onclick="setNewGameVariant('Wild 2', 'wild 2');">Wild 2</a></li>
+                                    <li><a class="dropdown-item" onclick="setNewGameVariant('Wild 3', 'wild 3');">Wild 3</a></li>
+                                    <li><a class="dropdown-item" onclick="setNewGameVariant('Wild 4', 'wild 4');">Wild 4</a></li>
+                                    <li><a class="dropdown-item" onclick="setNewGameVariant('Wild 5', 'wild 5');">Wild 5</a></li>
+                                    <li><a class="dropdown-item" onclick="setNewGameVariant('Wild 8', 'wild 8');">Wild 8</a></li>
+                                    <li><a class="dropdown-item" onclick="setNewGameVariant('Wild 8a', 'wild 8a');">Wild 8a</a></li>
+                                  </ul>
+                                </div>
+                                <div class="btn-group dropdown position-static" role="group" aria-label="Study">
                                   <button type="button" class="btn btn-outline-secondary btn-md" id="puzzlebot">Puzzle</button>
                                   <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Endgames</button>
                                   <ul class="dropdown-menu dropdown-menu-end" id="endgamebot">
-                                    <li><a class="dropdown-item" href="#" onclick="sessionSend('t endgamebot play kpk'); showGameTab();">kpk</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="sessionSend('t endgamebot play kbnk'); showGameTab();">kbnk</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="sessionSend('t endgamebot play kbbk'); showGameTab();">kbbk</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="sessionSend('t endgamebot play kqk'); showGameTab();">kqk</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="sessionSend('t endgamebot play krpkr'); showGameTab();">krpkr</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="sessionSend('t endgamebot play krk'); showGameTab();">krk</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="sessionSend('t endgamebot play kqkr'); showGameTab();">kqkr</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="sessionSend('t endgamebot play kpkp'); showGameTab();">kpkp</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="sessionSend('t endgamebot play kqpkq'); showGameTab();">kqpkq</a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="sessionSend('t endgamebot play knnkp'); showGameTab();">knnkp</a></li>
+                                    <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play kpk'); showGameTab();">kpk</a></li>
+                                    <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play kbnk'); showGameTab();">kbnk</a></li>
+                                    <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play kbbk'); showGameTab();">kbbk</a></li>
+                                    <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play kqk'); showGameTab();">kqk</a></li>
+                                    <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play krpkr'); showGameTab();">krpkr</a></li>
+                                    <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play krk'); showGameTab();">krk</a></li>
+                                    <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play kqkr'); showGameTab();">kqkr</a></li>
+                                    <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play kpkp'); showGameTab();">kpkp</a></li>
+                                    <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play kqpkq'); showGameTab();">kqpkq</a></li>
+                                    <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play knnkp'); showGameTab();">knnkp</a></li>
                                   </ul>
                                 </div>
                               </div>

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -221,7 +221,7 @@ export class Chat {
       $('#content-' + from).on('scroll', (e) => {
         var tab = e.target;
         if($(tab).hasClass('active')) {
-          var atBottom = tab.scrollHeight - tab.clientHeight <= tab.scrollTop + 1;      
+          var atBottom = tab.scrollHeight - tab.clientHeight < tab.scrollTop + 1.5;      
           if(atBottom) {
             $('#chat-scroll-button').hide();
             this.scrolledToBottom[$(tab).attr('id')] = true; 

--- a/src/clock.ts
+++ b/src/clock.ts
@@ -22,9 +22,7 @@ export function updateWhiteClock(game, wtime?: number) {
   const clock = game.color === 'w' ? $('#player-time') : $('#opponent-time');
   clock.text(SToHHMMSS(wtime));
 
-  if(game.wtime < 20) 
-    clock.addClass('low-time');
-  else
+  if(game.wtime >= 20) 
     clock.removeClass('low-time');
 }
 
@@ -35,9 +33,7 @@ export function updateBlackClock(game, btime?: number) {
   const clock = game.color === 'b' ? $('#player-time') : $('#opponent-time');
   clock.text(SToHHMMSS(btime));
 
-  if(game.btime < 20) 
-    clock.addClass('low-time');
-  else
+  if(game.btime >= 20) 
     clock.removeClass('low-time');
 }
 

--- a/src/clock.ts
+++ b/src/clock.ts
@@ -2,71 +2,155 @@
 // Use of this source code is governed by a GPL-style
 // license that can be found in the LICENSE file.
 
-/**
- * Convert seconds to HH:MM:SS.
- */
-export function SToHHMMSS(sec: number) {
-  const h = Math.abs(Math.floor(Math.abs(sec) / 3600));
-  const m = Math.abs(Math.floor(Math.abs(sec) % 3600 / 60));
-  const s = Math.abs(Math.floor(Math.abs(sec) % 3600 % 60));
-  return ((sec < 0 ? '-' : '')
-  + (h > 0 ? (h >= 0 && h < 10 ? '0' : '') + h + ':' : '')
-  + (m >= 0 && m < 10 ? '0' : '') + m + ':'
-  + (s >= 0 && s < 10 ? '0' : '') + s);
-}
+export class Clock {
+  private game: any;
+  private timer: any;
+  private wtime: number; // initial time for white clock (set after call to setClock() or stopClocks())
+  private btime: number; // initial time for black clock (set after call to setClock() or stopClocks())
+  private timestamp: number;
+  private runningClock: string; // 'w' if white clock running, 'b' for black, or '' if no clock running
+  private flagFallCallback: () => void;
 
-export function updateWhiteClock(game, wtime?: number) {
-  if(wtime === undefined)
-    wtime = game.wtime; 
+  constructor(game: any, flagFallCallback?: () => void) {
+    this.game = game;    
+    this.runningClock = '';
+    this.wtime = 0; 
+    this.btime = 0;
+    this.flagFallCallback = flagFallCallback;
+  }
 
-  const clock = game.color === 'w' ? $('#player-time') : $('#opponent-time');
-  clock.text(SToHHMMSS(wtime));
+  /**
+   * Convert milliseconds to HH:MM:SS.
+   */
+  public static MSToHHMMSS(milliseconds: number) {
+    const sec = Math.abs(Math.floor(Math.abs(milliseconds) / 1000));
+    const h = Math.abs(Math.floor(Math.abs(sec) / 3600));
+    const m = Math.abs(Math.floor(Math.abs(sec) % 3600 / 60));
+    const s = Math.abs(Math.floor(Math.abs(sec) % 3600 % 60));
+    return ((milliseconds < 0 ? '-' : '')
+    + (h > 0 ? (h >= 0 && h < 10 ? '0' : '') + h + ':' : '')
+    + (m >= 0 && m < 10 ? '0' : '') + m + ':'
+    + (s >= 0 && s < 10 ? '0' : '') + s);
+  }
 
-  if(game.wtime >= 20) 
-    clock.removeClass('low-time');
-}
-
-export function updateBlackClock(game, btime?: number) {
-  if(btime === undefined)
-    btime = game.btime; 
-
-  const clock = game.color === 'b' ? $('#player-time') : $('#opponent-time');
-  clock.text(SToHHMMSS(btime));
-
-  if(game.btime >= 20) 
-    clock.removeClass('low-time');
-}
-
-export function startBlackClock(game) {
-  return setInterval(() => {
-    if (game.chess.turn() === 'w') {
-      return;
-    }
-
-    game.btime = game.btime - 1;
-    const clock = game.color === 'w' ? $('#opponent-time') : $('#player-time');
-    if(game.btime < 20) 
-      clock.addClass('low-time');
+  /* When starting a clock, get the millisecond part of the time, and wait that long before
+    decrementing the clock the first time. 
+    e.g. Let's say wtime is 60533 (00:60.533), so wait 534 milliseconds until wtime is 59999 (00:59.999)
+    then set the clock to 00:59 and decrement it every 1000ms after that */
+  private static msTilNextInterval(time: number): number {
+    const millisecondPart = Math.abs(time) - (Math.floor(Math.abs(time) / 1000) * 1000);
+    if(time >= 0) 
+      return millisecondPart + 1;
     else
-      clock.removeClass('low-time');
-  
-    clock.text(SToHHMMSS(game.btime));
-  }, 1000);
-}
+      return 1000 - millisecondPart + 1;
+  }
 
-export function startWhiteClock(game) {
-  return setInterval(() => {
-    if (game.chess.turn() === 'b') {
-      return;
-    }
+  public setWhiteClock(time?: number) {
+    this.setClock('w', time);
+  }
 
-    game.wtime = game.wtime - 1;
-    const clock = game.color === 'w' ? $('#player-time') : $('#opponent-time');
-    if(game.wtime < 20)
-      clock.addClass('low-time');
+  public setBlackClock(time?: number) {
+    this.setClock('b', time);
+  }
+
+  public setClock(color: string, time?: number) {
+    if(time === undefined || time === null)
+      time = (color === 'w' ? this.game.wtime : this.game.btime);
+
+    if(this.getRunningClock() === color)
+      this.stopClocks();
+
+    this.updateClockElement(color, time);
+
+    if(color === 'w') 
+      this.wtime = time;
     else
-      clock.removeClass('low-time');
+      this.btime = time;
+  }
 
-    clock.text(SToHHMMSS(game.wtime));
-  }, 1000);
+  private updateClockElement(color: string, time: number) {
+    const clockElement = this.game.color === color ? $('#player-time') : $('#opponent-time');
+    //var sec = Math.abs(time < 0 ? Math.ceil(time / 1000) : Math.floor(time / 1000));
+    //clockElement.text((time < 0 ? '-' : '') + Clock.SToHHMMSS(sec)); // Add the - sign on separately to allow for -00:00
+    clockElement.text(Clock.MSToHHMMSS(time));
+
+    if(time >= 20000)
+      clockElement.removeClass('low-time');
+  }
+
+  public startBlackClock() {
+    this.startClock('b');
+  }
+
+  public startWhiteClock() {
+    this.startClock('w');
+  }
+
+  public startClock(color: string) {
+    this.stopClocks();
+    var initialTime = (color === 'w' ? this.wtime : this.btime);
+    this.runningClock = color;
+
+    // The timer waits a fractional amount until the next second ticks over
+    // e.g. if btime is 60.533 it waits until 59.999 
+    // After that the clock will be updated once a second.
+    var waitTime = Clock.msTilNextInterval(initialTime);
+    this.timestamp = performance.now();
+    var expectedTimeDiff = 0;
+
+    var timerFunc = () => { 
+      this.timer = null;
+
+      // Use timestamp to account for timing drift
+      expectedTimeDiff += waitTime;
+      var timeDiff = performance.now() - this.timestamp;
+      var timeAdjustment = expectedTimeDiff - timeDiff;
+
+      var time = initialTime - timeDiff;
+
+      if(time < 20000) {
+        const clockElement = this.game.color === color ? $('#player-time') : $('#opponent-time');
+        clockElement.addClass('low-time');
+      }
+
+      this.updateClockElement(color, time);
+
+      waitTime = 1000;
+      var adjustedWaitTime = Math.max(0, waitTime + timeAdjustment);
+      this.timer = setTimeout(timerFunc, adjustedWaitTime);
+
+      if(time < 0 && this.flagFallCallback)
+        this.flagFallCallback();
+    };
+    this.timer = setTimeout(timerFunc, waitTime);
+  }
+
+  public stopClocks() {
+    if(this.getRunningClock() === 'w')
+      this.wtime -= (performance.now() - this.timestamp);
+    else if(this.getRunningClock() === 'b')
+      this.btime -= (performance.now() - this.timestamp);
+    
+    clearTimeout(this.timer);
+    this.runningClock = '';  
+  }
+
+  public getWhiteTime(): number {
+    if(this.getRunningClock() === 'w')
+      return this.wtime - (performance.now() - this.timestamp);
+    else
+      return this.wtime;
+  }
+
+  public getBlackTime(): number {
+    if(this.getRunningClock() === 'b')
+      return this.btime - (performance.now() - this.timestamp);
+    else
+      return this.btime;
+  }
+
+  public getRunningClock(): string {
+    return this.runningClock;
+  }
 }
+

--- a/src/game.ts
+++ b/src/game.ts
@@ -23,8 +23,8 @@ class GameData {
   inc: number;                          // increment In seconds) of the match
   wstrength: number;                    // White material strength
   bstrength: number;                    // Black material strength
-  wtime: number;                        // White's remaining time
-  btime: number;                        // Black's remaining time
+  wtime: number;                        // White's remaining time in milliseconds
+  btime: number;                        // Black's remaining time in milliseconds
   moveNo: number;                       // the number of the move about to be made
   moveVerbose: {                        // verbose coordinate notation for the previous move
     from: string,                       // from square
@@ -35,6 +35,7 @@ class GameData {
   prevMoveTime: {                       // time taken to make previous move
     minutes: number,
     seconds: number,
+    milliseconds: number,
   };
   move: string;                         // pretty notation for the previous move ("none" if there is none)
   flip: boolean;                        // flip field for board orientation: 1 = Black at bottom, 0 = White at bottom.
@@ -54,8 +55,6 @@ class Game extends GameData {
   chess: any = null;
   color = 'w';
   history: any = null;
-  bclock: any = null;
-  wclock: any = null;
   watchers: any = null;
 }
 

--- a/src/history.ts
+++ b/src/history.ts
@@ -199,25 +199,25 @@ export class History {
     // Search forward and back through the current line we're in (mainline or subvariation)
     let i = this.id;
     do {
-      if(History.compareFENs(this.moves[i].fen, fen))
+      if(this.moves[i].fen === fen)
         return i;
       i = this.next(i);
     } while(i !== undefined);
 
     i = this.id;
     do {
-      if(History.compareFENs(this.moves[i].fen, fen))
+      if(this.moves[i].fen === fen)
         return i;
       i = this.prev(i);
     } while(i !== undefined);
 
     // Check whether the move is in a subvariation directly following the current mainline move
     if(this.id < this.length()) {
-      if(History.compareFENs(this.moves[this.id + 1].fen, fen))
+      if(this.moves[this.id + 1].fen === fen)
         return this.id + 1;
 
       if(this.id + 1 < this.length()) {
-        if(History.compareFENs(this.moves[this.id + 2].fen, fen))
+        if(this.moves[this.id + 2].fen === fen)
           return this.id + 2;
       }
     }
@@ -255,20 +255,6 @@ export class History {
     const ply = moveNo * 2 - (turnColor === 'w' ? 1 : 0);
 
     return ply;
-  }
-
-
-  // Tests equality for everything in the FENs except for halfmove clock
-  // This is necessary due to a bug in FICS where halfmove clock is not always set properly
-  public static compareFENs(fen1: string, fen2: string) : boolean {
-    var splitFen1 = fen1.split(/\s+/);
-    splitFen1[4] = '';
-    var fen1 = splitFen1.join();
-    var splitFen2 = fen2.split(/\s+/);
-    splitFen2[4] = '';
-    var fen2 = splitFen2.join();
-
-    return fen1 === fen2;
   }
 
   public static getMoveNoFromFEN(fen: string): number {

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ function initCategory() {
   // Check if game category (variant) is supported by Engine
   if(Engine.categorySupported(game.category)) {
     if(!evalEngine)
-      evalEngine = new EvalEngine(game.history, game.category);
+      evalEngine = new EvalEngine(game.history, {UCI_Chess960: game.category === 'wild/fr'});
     showAnalyzeButton();
   }
   else 
@@ -1297,9 +1297,9 @@ function parseVariantMove(fen: string, move: any, category: string) {
             var rightRook = square;
         }
       }
-      if(outMove.from === leftRook)
+      if(outMove.from === leftRook) 
         var leftRookMoved = true;
-      if(outMove.from === rightRook)
+      if(outMove.from === rightRook) 
         var rightRookMoved = true;
 
       if(leftRookMoved || rightRookMoved) {
@@ -2572,11 +2572,24 @@ function startEngine() {
     for(let i = 0; i < numPVs; i++)
       $('#engine-pvs').append('<li>&nbsp;</li>');
 
-    engine = new Engine(board, game.category, numPVs);
+    engine = new Engine(game.history, null, displayEnginePV, {UCI_Chess960: game.category === 'wild/fr', MultiPV: numPVs});
     if(!movelistRequested)
-      engine.move(game.history.get().fen);
-    else
-      engine.move(game.fen);
+      engine.move(game.history.index());
+  }
+}
+
+function displayEnginePV(pvNum: number, pvEval: string, pvMoves: string) {
+  $('#engine-pvs li').eq(pvNum - 1).html('<b>(' + pvEval + ')</b> ' + pvMoves + '<b/>');
+
+  if(pvNum === 1 && pvMoves) {
+    var words = pvMoves.split(/\s+/);
+    var san = words[0].split(/\.+/)[1];
+    var parsed = parseMove(game.history.get().fen, san, game.category);
+    board.setAutoShapes([{
+      orig: parsed.move.from,
+      dest: parsed.move.to,
+      brush: 'yellow',
+    }]);
   }
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -224,8 +224,8 @@ export class Parser {
     let match = null;
 
     // game move
-    match = msg.match(/<12>\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([BW\-])\s(\-?[0-7])\s([01])\s([01])\s([01])\s([01])\s([0-9]+)\s([0-9]+)\s([a-zA-Z]+)\s([a-zA-Z]+)\s(\-?[0-3])\s([0-9]+)\s([0-9]+)\s([0-9]+)\s([0-9]+)\s(\-?[0-9]+)\s(\-?[0-9]+)\s([0-9]+)\s(\S+)\s\(([0-9]+)\:([0-9]+)\)\s(\S+)\s([01])\s([0-9]+)\s([0-9]+)\s*/);
-    if (match != null && match.length >= 33) {
+    match = msg.match(/<12>\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([BW\-])\s(\-?[0-7])\s([01])\s([01])\s([01])\s([01])\s([0-9]+)\s([0-9]+)\s([a-zA-Z]+)\s([a-zA-Z]+)\s(\-?[0-3])\s([0-9]+)\s([0-9]+)\s([0-9]+)\s([0-9]+)\s(\-?[0-9]+)\s(\-?[0-9]+)\s([0-9]+)\s(\S+)\s\(([0-9]+)\:([0-9]+)\.([0-9]+)\)\s(\S+)\s([01])\s([0-9]+)\s([0-9]+)\s*/);
+    if (match != null && match.length >= 34) {
       var msgs = this.splitMessage(msg);
       if(msgs)
         return msgs;
@@ -262,15 +262,15 @@ export class Parser {
           from: moveMatches[1],
           to: moveMatches[2],
           promotion: moveMatches[3],
-          san: match[30]
+          san: match[31]
         };
       }
-      else if(match[30] === 'O-O' || match[30] === 'O-O-O') {
+      else if(match[31] === 'O-O' || match[31] === 'O-O-O') {
         moveVerbose = {
           from: 'e' + (match[9] === 'W' ? '8' : '1'),
-          to: (match[30] === 'O-O' ? 'g' : 'c') + (match[9] === 'W' ? '8' : '1'),
+          to: (match[31] === 'O-O' ? 'g' : 'c') + (match[9] === 'W' ? '8' : '1'),
           promotion: undefined,
-          san: match[30]
+          san: match[31]
         }
       }
 
@@ -285,13 +285,13 @@ export class Parser {
         inc: +match[21],                      // increment In seconds) of the match
         wstrength: +match[22],                // White material strength
         bstrength: +match[23],                // Black material strength
-        wtime: +match[24],                    // White's remaining time
-        btime: +match[25],                    // Black's remaining time
+        wtime: +match[24],                    // White's remaining time in milliseconds
+        btime: +match[25],                    // Black's remaining time in milliseconds
         moveNo: +match[26],                   // the number of the move about to be made
         moveVerbose,                          // verbose coordinate notation for the previous move ("none" if there werenone) [note this used to be broken for examined games]
-        prevMoveTime: {minutes: match[28], seconds: match[29]}, // time taken to make previous move "(min:sec)".
-        move: match[30],                      // pretty notation for the previous move ("none" if there is none)
-        flip: match[31] === '1'               // flip field for board orientation: 1 = Black at bottom, 0 = White at bottom.
+        prevMoveTime: {minutes: match[28], seconds: match[29], milliseconds: match[30]}, // time taken to make previous move "(min:sec)".
+        move: match[31],                      // pretty notation for the previous move ("none" if there is none)
+        flip: match[32] === '1'               // flip field for board orientation: 1 = Black at bottom, 0 = White at bottom.
       };
     }
 


### PR DESCRIPTION
Added the ability to select your color and rated/unrated for new games in the Play pairing panel
Re-wrote / refactored a bunch of stuff

Re-wrote clock.ts to keep track of time in milliseconds instead of seconds. 
Turned 'iset ms' on so we receive time remaining in milliseconds.
Now how clock.ts works is that if we receive a time like 00:59.423 remaining, we set a timeout to wait 423 + 1 ms
then set clock to 00:58 etc, then count down in seconds like usual. 
The new implementation uses setTimeout() in combination with performance.now() to keep the clock on time.

Refactored engine.ts:-
Added the ability for the engine to detect 3-fold repetition draws, by passing the whole move list to the engine instead of just the FEN.
Made EvalEngine inherit from Engine in order to get rid of repetitive code
Added the ability to specify callback functions to receive the bestmove and PVs (principle variations) 
Added the ability to pass options to the Engine (in preparation for adding an offline Play Computer mode)

Rewrote the code which handles variant moves:-
Fixed a bunch of Fischer Random bugs (WOW, some real doozies, like FICS allowing players to castle twice in the same game in some situations).
Separated this code into a parseVariantMove() function so that it's not clogging up the function for handling standard chess moves.

I'm about 3 quarters through adding a "Play Computer" feature, including the settings panel for it etc, but got sidetracked with all this other stuff. So thought I'd submit it separately. 