### PR TITLE
Status panel play computer fixes

### DIFF
--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -509,10 +509,6 @@ html, body {
   background-color: rgba(0, 0, 0, 0.05);
 }
 
-#play-computer-modal .modal-dialog {
-  width: 380px;
-}
-
 .modal {
   --bs-modal-color: var(--fg-color);
 }

--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -147,6 +147,16 @@ html, body {
   opacity: 0.6;
 }
 
+.clock {
+  align-items: baseline;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+
+.clock.my-turn {
+  background-color: rgba(0, 0, 0, 0.125);
+}
+
 .clock.low-time {
   color: red; 
 }

--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -123,8 +123,13 @@ html, body {
 
 .name {
   display: inline-block;
+  white-space: nowrap;
   font-size: 1.6rem;
   line-height: 21px;
+}
+
+.captured {
+  white-space: nowrap;
 }
 
 .captured img {

--- a/assets/css/themes/gray.css
+++ b/assets/css/themes/gray.css
@@ -218,4 +218,7 @@ cg-board {
   --bs-dropdown-header-color: #8c959d;
 }
 
+.clock.my-turn {
+  background-color: rgba(255, 255, 255, 0.075);
+}
 

--- a/play.html
+++ b/play.html
@@ -454,7 +454,7 @@
                   <div class="ms-auto p-2"></div>
                   <div class="p-2 captured" id="opponent-captured"></div>
                 </div>
-                <div class="clock d-flex ps-2 pe-2" id="opponent-clock" style="align-items: baseline;">
+                <div class="clock d-flex" id="opponent-clock">
                   <div class="clock-time" id="opponent-time"></div>
                   <div class="fractional-clock-time" id="opponent-fractional-time" style="display: none;"></div>
                 </div>
@@ -479,7 +479,7 @@
                   <div class="ms-auto p-2"></div>
                   <div class="p-2 captured" id="player-captured"></div>
                 </div>
-                <div class="clock d-flex ps-2 pe-2" id="player-clock" style="align-items: baseline;">
+                <div class="clock d-flex" id="player-clock">
                   <div class="clock-time" id="player-time"></div>
                   <div class="fractional-clock-time" id="player-fractional-time" style="display: none;"></div>
                 </div>

--- a/play.html
+++ b/play.html
@@ -445,11 +445,15 @@
         <div id="mid-col" class="col-sm-12 col-md-auto position-relative align-self-center">
           <div class="card bg-transparent" id="mid-card">
             <div class="top-panel card-header p-0" id="mid-panel-header">
-              <div class="ps-2 pe-2 h-100 w-100 d-flex flex-wrap justify-content-between align-items-center status noselect" id="opponent-status">
-                <div class="p-2 name" id="opponent-name"></div>
-                <span class="badge bg-secondary" id="opponent-rating"></span>
-                <div class="ms-auto p-2"></div>
-                <div class="p-2 captured" id="opponent-captured"></div>
+              <div class="ps-2 pe-2 h-100 w-100 d-flex justify-content-between align-items-center status noselect" id="opponent-status">
+                <div class="d-flex flex-grow-1 overflow-hidden">
+                  <div id="opponent-name-rating" class="d-flex flex-grow-1 overflow-hidden align-items-center">
+                    <div class="p-2 name" id="opponent-name"></div>
+                    <span class="badge bg-secondary" id="opponent-rating"></span>
+                  </div>
+                  <div class="ms-auto p-2"></div>
+                  <div class="p-2 captured" id="opponent-captured"></div>
+                </div>
                 <div class="clock d-flex ps-2 pe-2" id="opponent-clock" style="align-items: baseline;">
                   <div class="clock-time" id="opponent-time"></div>
                   <div class="fractional-clock-time" id="opponent-fractional-time" style="display: none;"></div>
@@ -466,11 +470,15 @@
               </div>
             </div>
             <div class="bottom-panel card-footer p-0" id="mid-panel-footer">
-              <div class="ps-2 pe-2 h-100 w-100 d-flex flex-wrap justify-content-between align-items-center status noselect" id="player-status">
-                <div class="p-2 name" id="player-name"></div>
-                <span class="badge bg-secondary" id="player-rating"></span>
-                <div class="ms-auto p-2"></div>
-                <div class="p-2 captured" id="player-captured"></div>
+              <div class="ps-2 pe-2 h-100 w-100 d-flex justify-content-between align-items-center status noselect" id="player-status">
+                <div class="d-flex flex-grow-1 overflow-hidden">
+                  <div id="player-name-rating" class="d-flex flex-grow-1 overflow-hidden align-items-center">
+                    <div class="p-2 name" id="player-name"></div>
+                    <span class="badge bg-secondary" id="player-rating"></span>
+                  </div>
+                  <div class="ms-auto p-2"></div>
+                  <div class="p-2 captured" id="player-captured"></div>
+                </div>
                 <div class="clock d-flex ps-2 pe-2" id="player-clock" style="align-items: baseline;">
                   <div class="clock-time" id="player-time"></div>
                   <div class="fractional-clock-time" id="player-fractional-time" style="display: none;"></div>
@@ -482,7 +490,7 @@
         <div id="right-col" class="col-sm-12 col-md-12 col-lg position-relative align-self-center" style="min-width: 360px">
           <div class="card bg-transparent" id="right-card">
             <div class="top-panel card-header status" id="right-panel-header" style="visibility: hidden">
-              <div id="user-dropdown" class="dropdown btn-toolbar my-auto me-auto" style="max-width: 50%">
+              <div id="user-dropdown" class="dropdown btn-toolbar my-auto me-auto" style="max-width: 44%">
                 <button class="w-100 btn btn-outline-secondary btn-md dropdown-toggle hide-caret" type="button" id="connectButton" data-bs-toggle="dropdown" title="Connect/Disconnect" aria-expanded="false" title="User">
                   <div id="chat-status" class="w-100"></div>
                 </button>

--- a/src/history.ts
+++ b/src/history.ts
@@ -35,7 +35,7 @@ export class History {
     this.add(undefined, fen, false, wtime, btime);
   }
 
-  public setClockTimes(index: number, wtime: number, btime: number) {
+  public updateClockTimes(index: number, wtime: number, btime: number) {
     if(index === undefined)
       index = this.id;
     
@@ -74,7 +74,7 @@ export class History {
     this.id++;
 
     this.moves.splice(this.id, 0, {move, fen, subvariation, opening: null});
-    this.setClockTimes(this.id, wtime, btime);
+    this.updateClockTimes(this.id, wtime, btime);
 
     if(move)
       this.addTableItem(move.san, History.getPlyFromFEN(fen), subvariation, this.id, score);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2730,10 +2730,10 @@ function getPlayComputerEngineOptions(): object {
 }
 
 function getPlayComputerMoveParams(): string {
-  var moveTimes = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]; // Move times (ms) for each difficulty level
-  // var maxDepths = [5, 5, 5, 5, 5, 8, 13, 22]; // Max search depths for each difficulty level 
-  
-  var moveParams = 'movetime ' + moveTimes[game.difficulty - 1];
+  // Max nodes for each difficulty level. This is also used to limit the engine's thinking time
+  // but in a way that keeps the difficulty the same across devices
+  var maxNodes = [100000, 200000, 300000, 400000, 500000, 600000, 700000, 800000, 900000, 1000000];
+  var moveParams = 'nodes ' + maxNodes[game.difficulty - 1];
 
   return moveParams;
 }


### PR DESCRIPTION
Made fixes to the top/bottom status panels, now the font-size of long player names is scaled down until the name fits.
If it still can't fit, then the name is truncated. The clock is never wrapped or obscured now.

Added 'your turn' highlighting to the clock to make it clearer whose turn it is.
Tell me if you think it looks good?

Implemented recommended changes regarding Play Computer difficulty
Now instead of 'movetime' the Computer's thinking time and difficulty is limited by the following max nodes for the 1-10 difficulty levels:
maxNodes = [100000, 200000, 300000, 400000, 500000, 600000, 700000, 800000, 900000, 1000000];
Limiting nodes is very similar to using movetime except the Computer will have the same difficulty no matter what device it's running on. On my phone (Google Pixel 7) for example, 1000000 nodes (lvl 10) is equivalent to about 1.5 seconds a move, whereas on my PC it's about 0.8s.



