### PR TITLE
Fix bug allobsRequested not decremented

### DIFF
--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -53,6 +53,10 @@ html, body {
   text-align: center;
 }
 
+.game-watchers {
+  white-space: pre-wrap;
+}
+
 #left-panel {
   height: 460px;
 }

--- a/play.html
+++ b/play.html
@@ -398,7 +398,7 @@
                         <div class="px-2 w-100 h-100">
                           <div class="game-status center py-1"></div>
                           <div class="opening-name center py-1 border-top" style="display: none"></div>
-                          <div class="game-watchers center pt-2 pb-1 border-top"></div>
+                          <div class="game-watchers center flex-wrap pt-2 pb-1 border-top"></div>
                         </div>
                       </div>
                     </div>
@@ -489,8 +489,8 @@
               </div>
               <div class="bottom-panel card-footer p-0">
                 <div class="h-100 w-100 d-flex justify-content-between align-items-center status noselect player-status">
-                  <div class="d-flex flex-grow-1 overflow-hidden">
-                    <div class="d-flex flex-grow-1 overflow-hidden align-items-center name-rating">
+                  <div class="d-flex flex-grow-1 overflow-x-hidden">
+                    <div class="d-flex flex-grow-1 overflow-x-hidden align-items-center name-rating">
                       <div class="name"></div>
                       <span class="badge bg-secondary rating"></span>
                     </div>

--- a/src/game.ts
+++ b/src/game.ts
@@ -82,8 +82,5 @@ export class Game extends GameData {
 
   lastComputerMoveEval: string = null; // Keeps track of the current eval for a game against the Computer. Used for draw offers
   partnerGameId: number = null;        // bughouse partner's game id
-}
-
-class GameList {
-
+  allobsRequested: number = 0;         // Keeps track of requests for watchers
 }


### PR DESCRIPTION
Fixed a few more bugs.

allobsRequested counter wasn't being decremented when "No one is observing game <#>" was received.
Also I moved allobsRequested into the game object, because it seems like it would be more robust having a separate variable for each game. Also watchers list wasn't wrapping properly.

Fixed a couple of bugs I introduced lately, player names were being clipped incorrectly and I accidently broke the flipBoard() function, but fixed now. 