### PR TITLE
Fix player names and removeGame() cleanup

### DIFF
--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -130,8 +130,7 @@ html, body {
   white-space: nowrap;
   font-size: 1.6rem;
   line-height: 21px;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding: 0.5rem;
 }
 
 .captured {
@@ -249,8 +248,7 @@ html, body {
 
 .game-card-sm .name {
   font-size: inherit;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding: 0.5rem;
 }
 
 .game-card-sm .rating {

--- a/src/game.ts
+++ b/src/game.ts
@@ -82,5 +82,4 @@ export class Game extends GameData {
 
   lastComputerMoveEval: string = null; // Keeps track of the current eval for a game against the Computer. Used for draw offers
   partnerGameId: number = null;        // bughouse partner's game id
-  allobsRequested: number = 0;         // Keeps track of requests for watchers
 }


### PR DESCRIPTION
- Ok, I added the vertical padding back to the player names, I should have never removed that in the first place whoops!
- I fixed a few more of the bugs you discovered. I somehow forgot to call cleanupGame() in removeGame() so games were being completely deleted without the watchers interval being cleared.
- I changed allobsRequested back to being global instead of in the game object. I realised having it in the game object was more complicated than I first thought.
- Fixed an issue with movelistRequested being set for multiple games at once.
- The error you noticed involving history.current() was in the showOpeningNames() function which was being called after the game was removed due to it being asynchronous
-  Also added some more guards checking whether game exists before updating watchers etc. 
- Added your thing to check for 'There is no such game.' 
