### PR TITLE
Game tools

### DIFF
--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -34,13 +34,11 @@ html, body {
 }
 
 #game-requests {
-  position: absolute;
   width: 100%;
   height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 100;
 }
 
 .game-status {
@@ -59,6 +57,10 @@ html, body {
 
 #left-panel {
   height: 460px;
+}
+
+#left-panel.list-view-showing {
+  height: 200px;
 }
 
 #left-panel-bottom {
@@ -296,6 +298,20 @@ html, body {
   flex-wrap: wrap;
 }
 
+#game-toolbar .btn {
+  --bs-btn-active-color: rgba(159, 184, 228, 0.75);
+  --bs-btn-active-bg: transparent;
+  --bs-btn-hover-bg: transparent;
+  --bs-btn-hover-border-color: transparent;
+  --bs-btn-border-color: transparent; 
+  --bs-btn-active-border-color: transparent;
+}
+
+#game-tools-close .dropdown-icon {
+  padding-left: 0.125rem; 
+  padding-right: 0.25rem;
+}
+
 #move-table {
   padding: 0;
 }
@@ -341,6 +357,26 @@ html, body {
   padding-left: 15px; 
   padding-right: 15px;
   font-weight: bold;
+}
+
+.movelist .selected {
+  background-color: rgba(0, 0, 0, 0.2);
+  color: #000000;
+}
+.movelist .subvariation {
+  color: #5e4d3b;
+}
+.movelist .subvariation .selected {
+  background-color: rgba(0, 0, 0, 0.2);
+  color: #2e2418;
+}
+.movelist .move:hover,
+.movelist .subvariation .move:hover {
+  color: rgb(10, 88, 202);
+}
+.movelist .selected:hover,
+.movelist .subvariation .selected:hover {
+  color: rgb(10, 88, 202);
 }
 
 .nav-tabs .nav-item .closeTab {
@@ -614,3 +650,24 @@ html, body {
 .form-heading {
   color: #638FA8;
 }
+
+.dropdown-menu li { 
+  position: relative; 	
+}
+.dropdown-submenu{  
+  display: none;
+  position: absolute;
+  left:100%;
+  top:-7px;
+}
+.dropdown-submenu-left { 
+  right:100%; left:auto;
+}
+.dropdown-menu > li:hover > .dropdown-submenu{ display: block; }
+@media (max-width: 767px) {
+  .dropdown-submenu {
+    right:100%; left:auto;
+    min-width: 0;
+  }
+}	
+

--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -299,7 +299,6 @@ html, body {
 #move-table {
   padding: 0;
 }
-
 #move-table th {
   border: 0;
   width: 20%;
@@ -307,48 +306,36 @@ html, body {
   font-weight: bold;
   color: rgba(0, 0, 0, 0.4);
 }
-
 #move-table td {
   border: 0;
   width: 40%;
   text-align: center;
 }
-
 #move-table .selectable:hover {
   background-color: rgba(0, 0, 0, 0.075);
 }
-
 #move-table .subvariation:hover {
   background-color: rgba(255, 255, 255, 0.075);
 }
-
 #move-table .selectable:hover a {
   font-weight: bold;
   text-decoration: none;
 }
-
-#move-table .subvariation td {
-  background: #D7D7D7;
-}
-
+#move-table .subvariation td,
 #move-table .subvariation th {
-  background: #D7D7D7;
+  background: rgba(0, 0, 0, 0.15);
 }
-
-#move-table tr:nth-of-type(odd) {
+#move-table tr:nth-of-type(odd):not(.subvariation) {
   background-color: rgba(0, 0, 0, 0.05);
 }
-
 #move-table .subvariation .selected {
-  background-color: #BBBBBB; 
+  background-color: rgba(0, 0, 0, 0.15);
 }
-
 #move-table .subvariation a {
   color: #191970
 }
-
 #move-table .selected {
-  background-color: #DDDDDD; 
+  background-color: rgba(0, 0, 0, 0.1);
   padding-top: 2px; 
   padding-bottom: 3px; 
   padding-left: 15px; 

--- a/assets/css/themes/gray.css
+++ b/assets/css/themes/gray.css
@@ -116,26 +116,24 @@ cg-board {
 #move-table th {
   color: rgba(255, 255, 255, 0.4);
 }
-#move-table tr:nth-of-type(odd) {
+#move-table tr:nth-of-type(odd):not(.subvariation) {
   background-color: rgba(0, 0, 0, 0.08);
 }
 #move-table .selectable:hover {
   background-color: rgba(255, 255, 255, 0.06);
 }
 #move-table .selected {
-  background-color: #606060; 
+  background-color: rgba(255, 255, 255, 0.15);
 }
 #move-table .subvariation:hover {
   background-color: rgba(0, 0, 0, 0.05);
 }
 #move-table .subvariation .selected {
-  background-color: #777777; 
+  background-color: rgba(255, 255, 255, 0.2);
 }
-#move-table .subvariation td {
-  background: #606060;
-}
+#move-table .subvariation td,
 #move-table .subvariation th {
-  background: #606060;
+  background: rgba(255, 255, 255, 0.15);
 }
 #move-table .subvariation a {
   color: #DDDDDD

--- a/assets/css/themes/gray.css
+++ b/assets/css/themes/gray.css
@@ -139,6 +139,26 @@ cg-board {
   color: #DDDDDD
 }
 
+.movelist .selected {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: #FFFFFF;
+}
+.movelist .subvariation {
+  color: #AAAAAA;
+}
+.movelist .subvariation .selected {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: #DDDDDD;
+}
+.movelist .move:hover,
+.movelist .subvariation .move:hover {
+  color: rgb(10, 88, 202);
+}
+.movelist .selected:hover,
+.movelist .subvariation .selected:hover {
+  color: rgb(5, 44, 101);
+}
+
 #engine-pvs > li:nth-of-type(even) {
   background-color: rgba(0, 0, 0, 0.08);
 }

--- a/play.html
+++ b/play.html
@@ -76,7 +76,7 @@
               </div>
             </div>
             <div id="inner-left-panels">
-              <div id="close-game-panel" class="card-header top-panel center" style="display: none">
+              <div id="left-panel-header-2" class="card-header top-panel center" style="display: none">
                 <button type="button" id="stop-observing" style="display: none" class="btn btn-outline-secondary btn-md" title="Stop Observing"><span class="fa fa-times-circle me-2" aria-hidden="false"></span>Stop Observing</button>         
                 <button type="button" id="stop-examining" style="display: none" class="btn btn-outline-secondary btn-md" title="Stop Examining"><span class="fa fa-times-circle me-2" aria-hidden="false"></span>Stop Examining</button>         
               </div>
@@ -99,8 +99,8 @@
               <div id="collapse-history" class="collapse show collapse-init">
                 <div class="card-body noselect p-0" id="left-panel">
                   <div class="h-100 d-flex flex-column" id="left-menu">
-                    <div class="tab-content mt-2 flex-grow-1" style="overflow: hidden; min-height: 0">
-                      <div class="tab-pane fade show active h-100" id="pills-play" role="tabpanel" aria-labelledby="pills-play-tab">
+                    <div class="tab-content flex-grow-1" style="overflow: hidden; min-height: 0">
+                      <div class="tab-pane pt-2 fade show active h-100" id="pills-play" role="tabpanel" aria-labelledby="pills-play-tab">
                         <div class="d-flex flex-column h-100">
                           <div class="modal fade" id="play-computer-modal" tabindex="-1" aria-labelledby="play-computer-modal-label" aria-hidden="true">
                             <div class="modal-dialog modal-dialog-centered">
@@ -336,7 +336,7 @@
                           </div>
                         </div>
                       </div>
-                      <div class="tab-pane fade h-100" id="pills-observe" role="tabpanel" aria-labelledby="pills-observe-tab">
+                      <div class="tab-pane pt-2 fade h-100" id="pills-observe" role="tabpanel" aria-labelledby="pills-observe-tab">
                         <div class="d-flex flex-column h-100">
                           <div class="center pane-status" id="observe-pane-status" style="display: none"></div>
                           <form id="observe-user">
@@ -349,7 +349,7 @@
                           <div class="flex-grow-1 overflow-auto" style="min-height: 0" id="games-table"></div>
                         </div>
                       </div>
-                      <div class="tab-pane fade h-100" id="pills-examine" role="tabpanel" aria-labelledby="pills-examine-tab">
+                      <div class="tab-pane pt-2 fade h-100" id="pills-examine" role="tabpanel" aria-labelledby="pills-examine-tab">
                         <div class="d-flex flex-column h-100">
                           <div class="center pane-status" id="examine-pane-status" style="display: none"></div>
                           <form id="examine-user">
@@ -362,11 +362,54 @@
                           <div class="flex-grow-1 overflow-auto" style="min-height: 0" id="history-table"></div>
                         </div>
                       </div>
-                      <div class="tab-pane h-100 fade overflow-auto" id="pills-game" role="tabpanel" aria-labelledby="pills-game-tab">
-                        <span class="center" id="playing-game">You're not playing a game.</span>
-                        <table id="move-table" class="table table-sm">
-                          <tbody></tbody>
-                        </table>
+                      <div class="tab-pane h-100 fade" id="pills-game" role="tabpanel" aria-labelledby="pills-game-tab">
+                        <div class="d-flex flex-column h-100">
+                          <div id="game-toolbar" class="d-flex justify-content-end pb-1 pt-1 pe-2" style="gap: 14px">
+                            <div class="btn-group">
+                              <input type="radio" checked class="btn-check" name="view-mode" id="game-table-view" autocomplete="off">
+                              <label class="btn btn-outline-secondary btn-sm" for="game-table-view" data-bs-toggle="tooltip" data-bs-placement="left" data-bs-placement-md="top" title="Table View">
+                                <span class="fa-solid fa-table-columns" aria-hidden="false"></span>
+                              </label>
+                              <input type="radio" class="btn-check" name="view-mode" id="game-list-view" autocomplete="off">
+                              <label class="btn btn-outline-secondary btn-sm" for="game-list-view" data-bs-toggle="tooltip" data-bs-placement="top" title="List View">
+                                <span class="fa-solid fa-align-justify" aria-hidden="false"></span>
+                              </label>
+                            </div>
+                            <input type="checkbox" class="btn-check" id="game-preserved" autocomplete="off" aria-checked="false">
+                            <label class="btn btn-outline-secondary btn-sm" for="game-preserved" data-bs-toggle="tooltip" data-bs-placement="top" title="Preserve Game">
+                              <span class="fa-solid fa-unlock" aria-hidden="false"></span>
+                            </label>
+                            <div>
+                              <button type="button" id="more-game-tools" class="btn btn-outline-secondary btn-sm dropdown-toggle hide-caret" data-bs-toggle="dropdown" aria-expanded="false" title="More tools">
+                                <span class="fa-solid fa-ellipsis-vertical" aria-hidden="false"></span>
+                              </button>
+                              <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="more-game-tools">
+                                <li><a class="dropdown-item noselect" id="game-tools-new"><span class="fa-solid fa-file-circle-plus dropdown-icon" aria-hidden="false"></span>New Game</a></li>
+                                <li>
+                                  <a class="dropdown-item dropdown-toggle noselect" id="game-tools-new-variant"><span class="fa-solid fa-file-circle-plus dropdown-icon" aria-hidden="false"></span>New Variant Game</a>
+                                  <ul class="dropdown-menu dropdown-submenu" id="new-variant-game-submenu" aria-labelledby="game-tools-new-variant">
+                                    <li><a class="dropdown-item noselect">Chess960</a></li>
+                                    <li><a class="dropdown-item noselect">Crazyhouse</a></li>
+                                    <li><a class="dropdown-item noselect">Losers</a></li>
+                                  </ul>
+                                </li>
+                                <li><a class="dropdown-item noselect" id="game-tools-clone"><span class="fa-solid fa-copy dropdown-icon" aria-hidden="false"></span>Clone Game</a></li>
+                                <li><a class="dropdown-item noselect" id="game-tools-examine"><span class="fa-brands fa-slideshare dropdown-icon" aria-hidden="false"></span>Examine Mode (Shared)</a></li>
+                                <li style="display: none"><hr id="game-tools-close-divider" class="dropdown-divider"></li>
+                                <li style="display: none"><a class="dropdown-item noselect" id="game-tools-close"><span class="fa-solid fa-xmark dropdown-icon" aria-hidden="false"></span>Close Game</a></li>
+                              </ul>
+                            </div>
+                          </div>
+                          <span class="center" id="game-pane-status">You're not playing a game.</span>
+                          <div id="movelist-container" class="flex-grow-1 overflow-auto" style="min-height: 0">
+                            <table id="move-table" class="table table-sm">
+                              <tbody></tbody>
+                            </table>
+                            <div id="movelists">
+                              <div class="movelist px-2 flex-wrap" style="display: flex"></div>
+                            </div>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -451,7 +494,7 @@
           </div>
         </div>
         <div id="mid-col" class="col-sm-12 col-md-auto position-relative align-self-center">
-          <div class="toast-container h-100 w-100">
+          <div class="toast-container h-100 w-100" style="z-index: 100;">
             <div id="game-requests" aria-live="polite" aria-atomic="true"></div>
           </div>
           <div id="main-board-area">
@@ -664,7 +707,7 @@
                         <button class="text-sm-center nav-link active" data-bs-toggle="tab" href="#content-console" id="tab-console" role="tab">Console</button>
                       </li>
                     </ul>
-                    <button class="align-self-start btn btn-outline-secondary btn-sm hide-caret" style="display: none" type="button" id="collapse-chat-arrow" aria-label="Close Chat">
+                    <button class="align-self-start btn btn-outline-secondary btn-sm" style="display: none" type="button" id="collapse-chat-arrow" aria-label="Close Chat">
                       <span class="fa-solid fa-arrow-up" aria-hidden="false"></span>
                     </button>
                   </div>

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -369,13 +369,13 @@ function scrollToChat() {
 $('#chat-maximize-btn').on('click', () => {
   if (maximized) {
     $('#chat-maximize-icon').removeClass('fa-toggle-right').addClass('fa-toggle-left');
-    $('#chat-maximize-btn').attr('data-bs-original-title', 'Maximize');
+    $('#chat-maximize-btn').attr('title', 'Maximize');
     if($('#secondary-board-area > .game-card').length)
       $('#secondary-board-area').css('display', 'flex');
     maximized = false;
   } else {
     $('#chat-maximize-icon').removeClass('fa-toggle-left').addClass('fa-toggle-right');
-    $('#chat-maximize-btn').attr('data-bs-original-title', 'Unmaximize');
+    $('#chat-maximize-btn').attr('title', 'Unmaximize');
     $('#collapse-chat').collapse('show');
     $('#secondary-board-area').hide();
     maximized = true;

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -192,6 +192,7 @@ export class Chat {
     }
 
     this.user = user;
+    this.userRE = new RegExp('\\b' + user + '\\b', 'ig');
   }
 
   public createTab(name: string, showTab = false) {
@@ -289,7 +290,7 @@ export class Chat {
     });
   }
 
-  public newMessage(from: string, data: any) {
+  public newMessage(from: string, data: any, html: boolean = false) {
     let tabName = chattabsToggle ? from : 'console';
     const tab = this.createTab(tabName);
     let who = '';
@@ -305,7 +306,9 @@ export class Chat {
       who = '<strong' + textclass + '>' + $('<span/>').text(prompt).html() + '</strong>: ';
     }
 
-    let text = this.escapeHTML(data.message);
+    let text = data.message;
+    if(!html)
+      text = this.escapeHTML(text);
     if (this.emojisLoaded) {
       text = parseEmojis(text);
     }
@@ -350,7 +353,7 @@ export class Chat {
     else 
       var currentTab = 'console';
 
-    this.newMessage(currentTab, {message: msg});
+    this.newMessage(currentTab, {message: msg}, true);
   }
 }
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -13,38 +13,38 @@ export const Role = {
   PLAYING_COMPUTER: -998    // I am playing the Computer locally
 };
 
-class GameData {
-  fen: string;                          // game position
-  turn: string;                         // color whose turn it is to move ("B" or "W")
-  id: number;                           // The game number
-  wname: string;                        // White's name
-  bname: string;                        // Black's name
-  role: number;                         // my relation to this game
-  time: number;                         // initial time (in seconds) of the match
-  inc: number;                          // increment In seconds) of the match
-  wstrength: number;                    // White material strength
-  bstrength: number;                    // Black material strength
-  wtime: number;                        // White's remaining time in milliseconds
-  btime: number;                        // Black's remaining time in milliseconds
-  moveNo: number;                       // the number of the move about to be made
+export class GameData {
+  fen: string = '';                     // game position
+  turn: string = 'W';                   // color whose turn it is to move ("B" or "W")
+  id: number = -1;                      // The game number
+  wname: string = '';                   // White's name
+  bname: string = '';                   // Black's name
+  role: number = Role.NONE;             // my relation to this game
+  time: number = 0;                     // initial time (in seconds) of the match
+  inc: number = 0;                      // increment In seconds) of the match
+  wstrength: number = 0;                // White material strength
+  bstrength: number = 0;                // Black material strength
+  wtime: number = 0;                    // White's remaining time in milliseconds
+  btime: number = 0;                    // Black's remaining time in milliseconds
+  moveNo: number =  1;                  // the number of the move about to be made
   moveVerbose: {                        // verbose coordinate notation for the previous move
     from: string,                       // from square
     to: string,                         // to square
     promotion: string,                  // promotion piece
     san: string,                        // move in algebraec form
-  };
+  } = null;
   prevMoveTime: {                       // time taken to make previous move
     minutes: number,
     seconds: number,
     milliseconds: number,
-  };
-  move: string;                         // pretty notation for the previous move ("none" if there is none)
+  } = null;
+  move: string = '';                    // pretty notation for the previous move ("none" if there is none)
   flip: boolean = false;                // flip field for board orientation: 1 = Black at bottom, 0 = White at bottom.
-  wrating: string;                      // white's rating
-  brating: string;                      // black's rating
+  wrating: string = '';                 // white's rating
+  brating: string = '';                 // black's rating
   category: string = '';                // category or variant
   color: string = 'w';
-  difficulty: number;                   // computer difficulty level
+  difficulty: number = 0;               // computer difficulty level
 
   public isPlaying() { return this.role === Role.MY_MOVE || this.role === Role.OPPONENTS_MOVE || this.role === Role.PLAYING_COMPUTER; }
   public isPlayingOnline() { return this.role === Role.MY_MOVE || this.role === Role.OPPONENTS_MOVE; }
@@ -64,6 +64,7 @@ export class Game extends GameData {
   // HTML elements associated with this Game
   element: any = null; // The main game card including the board
   moveTableElement: any = null; // The move list (in 2 column table form)
+  moveListElement: any = null; // The move list (in PGN form)
   statusElement: any = null; // The status panel 
 
   // Keep track of which analysis tab is showing
@@ -83,4 +84,6 @@ export class Game extends GameData {
 
   lastComputerMoveEval: string = null; // Keeps track of the current eval for a game against the Computer. Used for draw offers
   partnerGameId: number = null;        // bughouse partner's game id
+  preserved: boolean = false;          // if true, prevents a game/board from being overwritten 
+  commitingMovelist = false;           // Used when entering examine mode and using 'commit' to submit a move list
 }

--- a/src/game.ts
+++ b/src/game.ts
@@ -47,6 +47,7 @@ class GameData {
   difficulty: number;                   // computer difficulty level
 
   public isPlaying() { return this.role === Role.MY_MOVE || this.role === Role.OPPONENTS_MOVE || this.role === Role.PLAYING_COMPUTER; }
+  public isPlayingOnline() { return this.role === Role.MY_MOVE || this.role === Role.OPPONENTS_MOVE; }
   public isExamining() { return this.role === Role.EXAMINING; }
   public isObserving() { return this.role === Role.OBSERVING || this.role === Role.OBS_EXAMINED; }
 }


### PR DESCRIPTION
Here's the game tab toolbar I was working on.
From left to right:-
Added a list (pgn) view mode for the move list.
I made this the default mode for mobile, and made it so that the Game pane shrinks to a height of 200px when viewing the game tab in this mode. So that user can view most of it in the same screen as the board and doesn't have to scroll as far to see it. Let me know if you think that's a good idea? I've almost gotten the code to the stage where nested subvariations / multiple subvariations work. But this still needs a bit more work, so for now the move list still just has one subvariation at a time.

Next there is a 'Preserve Game' button which looks like a lock icon. Normally when you start a new game, it will re-use a board which is not currently Playing/Examining/Observing. However if the user wants to keep that game/board, they can lock it. In which case it will open a new 2nd board. This is only visible in multi-board mode.

Lastly there is a drop-down menu containing:-
New Game - This pops up a dialog that asks the user whether they want to overwrite the current game or open a new board.
If they select to overwrite, it clears the move list, status panel etc and resets the game to a fresh state. Otherwise it opens a new mini-board in a fresh state.

Clone Game - This copies the current game/board exactly and puts it in a mini-board over the side. Except that if you clone a game you're observing, the clone won't be in observe mode. So you can freely move the pieces around and analyze a game you're observing etc. Atm it's a bit hard to tell the clone apart from the original, as they have the same status message. The only difference really is that the clone won't have clocks running, and it won't have a 'Stop Observing' button. But perhaps there should be some other indiciation in the status panel or the title bar to indicate it's a copy.

Examine Mode (Shared) - This option is used to convert a game which is not currently in Examine Mode into one in Examine Mode. If you use it on a game you're Observing, it will clone the game into a new window first, and then enter examine mode. Otherwise it'll just enter examine mode in the same window. 
It enters examine mode by starting a scratch game 'ex' then using 'bsetup' to send the move list and player names to FICS. Then uses 'commit' to commit the move list to the server. 
For example after you play a game; as an alternative to going to the Examine pane, and selecting the last game you played from your History, You can just go to this Examine Mode option and it'll convert the game to Examine Mode. 

Lastly if there are multiple boards open, then a 'Close Game' option will also appear in the menu, allowing the user to close the main (maximized) game for example. If the game is preserved/locked then pressing the close button will also make a confirmation dialog appear. 

The other commit contains a bunch of bug fixes. Some of the bugs are to do with Adjourned games, which weren't working well at all. In particular due to a bad bug I introduced a long time ago (whoops!) but also some other bugs.
I also just generally improved adjourned game support:-
Now a dialog pops up when a user requests to adjourn a game, and also when a person has lagged for more than 30 seconds and courtesy adjourn becomes available. 
There are also slide-down notifications now when a user you have an adjourned game with comes online. And when you first join the server it shows you if there are players you have adjourned games with online.
See the full list of bug fixes in the commit.