### PR TITLE
Chat improvements

### DIFF
--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -23,6 +23,10 @@ html, body {
   min-height: 100%;
 }
 
+#chat-panel {
+  display: flex;
+}
+
 .chat-text {
   width: 100%;
   overflow: auto;

--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -33,6 +33,20 @@ html, body {
   color: rgba(80, 80, 120, 0.65);
 }
 
+.chat-text-suffix {
+  font-style: italic;
+  color: #8E9DA5;
+}
+
+#collapse-chat-arrow {
+  display: none;
+}
+@media (min-width: 768px) {
+  #collapse-chat-arrow {
+    display: none !important;
+  }
+}
+
 #game-requests {
   width: 100%;
   height: 100%;
@@ -307,6 +321,14 @@ html, body {
   --bs-btn-active-border-color: transparent;
 }
 
+#game-toolbar {
+  padding-top: 3px;
+  padding-bottom: 3px;
+  padding-right: 0.5rem;
+}
+#game-toolbar .btn {
+  --bs-btn-active-color: rgba(159, 184, 228, 0.75);
+}
 #game-tools-close .dropdown-icon {
   padding-left: 0.125rem; 
   padding-right: 0.25rem;

--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -61,6 +61,10 @@ html, body {
   color: rgba(80, 80, 120, 0.65);
 }
 
+.game-status .game-id {
+  font-weight: normal;
+}
+
 .opening-name {
   text-align: center;
 }
@@ -235,6 +239,15 @@ html, body {
   padding-bottom: 0px;
   padding-left: 5px;
   padding-right: 5px;
+}
+
+.game-card .title-bar-text {
+  font-size: 0.8em;
+  line-height: 1;
+  user-select: none; 
+  cursor: default; 
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .game-card .title-bar .btn {

--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -698,3 +698,15 @@ html, body {
   }
 }	
 
+.tooltip-separator {
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
+.tooltip-overlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}

--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -115,6 +115,10 @@ html, body {
   transform: translateX(-50%);
 }
 
+#input-text {
+  resize: none;   
+}
+
 .counter-bubble {
   fill: red;
 }
@@ -203,6 +207,7 @@ html, body {
   padding-top: 0;
   padding-bottom: 0;
   display: flex;  
+  flex-shrink: 0;
 }
 
 .game-card {

--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -18,10 +18,13 @@ html, body {
   min-height: 100vh;
 }
 
+#chat-tabContent .tab-pane {
+  max-height: 100%; 
+  min-height: 100%;
+}
+
 .chat-text {
   width: 100%;
-  max-height: 100%;
-  min-height: 100%;
   overflow: auto;
   color: rgba(0, 0, 0, 0.65);
   white-space: pre-wrap;
@@ -44,6 +47,34 @@ html, body {
 @media (min-width: 768px) {
   #collapse-chat-arrow {
     display: none !important;
+  }
+}
+
+.chat-info {
+  display: none;
+  height: 31px;
+  padding-left: 8px;
+  padding-right: 8px;
+  background-color: rgba(255, 255, 255, 0.4);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+}
+.chat-info .btn-outline-secondary {
+  --bs-btn-color: rgba(80, 80, 120, 0.65);
+  --bs-btn-hover-color: rgba(159, 184, 228, 0.75);
+  --bs-btn-active-color: rgba(159, 184, 228, 0.75);
+  font-weight: bold;
+  white-space: nowrap;
+}
+@media (max-width: 767px) {
+  .chat-watchers-text {
+   display: none; 
+  }
+}
+@media (min-width: 768px) {
+  .chat-watchers-text {
+    display: block;
+    font-style: italic;
+    margin-right: 6px;
   }
 }
 
@@ -143,7 +174,7 @@ html, body {
     margin-right: 0;
 }
 
-#chat-status {
+#session-status {
   display: inline-flex;
   align-items: center;
   overflow: hidden;
@@ -253,11 +284,6 @@ html, body {
 .game-card .title-bar .btn {
   padding: 2px;
   line-height: 1;
-  --bs-btn-active-bg: transparent;
-  --bs-btn-hover-bg: transparent;
-  --bs-btn-border-color: transparent; 
-  --bs-btn-active-border-color: transparent;
-  --bs-btn-hover-border-color: transparent;
 }
 
 .game-card .title-bar .game-maximize-icon {
@@ -330,8 +356,7 @@ html, body {
   flex-wrap: wrap;
 }
 
-#game-toolbar .btn {
-  --bs-btn-active-color: rgba(159, 184, 228, 0.75);
+.btn-transparent {
   --bs-btn-active-bg: transparent;
   --bs-btn-hover-bg: transparent;
   --bs-btn-hover-border-color: transparent;

--- a/assets/css/themes/gray.css
+++ b/assets/css/themes/gray.css
@@ -17,7 +17,7 @@ cg-board {
   background-color: var(--bg-color);
   color: var(--fg-color);
 }
-.chat-text,.card-header,.card-footer {
+.chat-text {
   color: lightgray;
 }
 .top-panel,.bottom-panel {
@@ -106,6 +106,7 @@ cg-board {
 
 .card {
   --bs-card-border-color: #555555;
+  --bs-card-cap-color: lightgray;
   --bs-card-cap-bg: rgba(0, 0, 0, 0.06);
 }
 
@@ -192,14 +193,6 @@ cg-board {
   --bs-progress-bar-bg: #0d6efd;
 }
 
-.game-card {
-  --game-tie-color: #654D2F;
-  --game-win-color: #35644D;
-  --game-lose-color: #804545;
-  --border-expand-color: #FFFFFF;
-  --border-expand-width: 1px;
-}
-
 .clock.low-time {
   color: red;
 }
@@ -243,10 +236,16 @@ cg-board {
   background-color: rgba(255, 255, 255, 0.075);
 }
 
+.game-card {
+  --game-tie-color: #654D2F;
+  --game-win-color: #35644D;
+  --game-lose-color: #804545;
+  --border-expand-color: #FFFFFF;
+  --border-expand-width: 1px;
+}
 .game-card .title-bar {
   --bs-card-cap-bg: #464646;
 }
-
 .game-card .title-bar .btn span {
   filter: brightness(0.9);
 }

--- a/assets/css/themes/gray.css
+++ b/assets/css/themes/gray.css
@@ -20,11 +20,18 @@ cg-board {
 .chat-text {
   color: lightgray;
 }
-.top-panel,.bottom-panel {
-  color: lightslategray;
-}
 .chat-text strong, a {
   color: rgba(159, 184, 228, 0.75);
+}
+.chat-info {
+  background-color: rgba(255, 255, 255, 0.035);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+.chat-info .btn-outline-secondary {
+  --bs-btn-color: rgba(240, 159, 67, 0.95);
+}
+.top-panel,.bottom-panel {
+  color: lightslategray;
 }
 .game-status,.game-watchers,.chat-text strong.mine {
   color: rgba(240, 159, 67, 0.95);

--- a/assets/css/themes/green.css
+++ b/assets/css/themes/green.css
@@ -1,6 +1,9 @@
 .feature3 {
   background-color: #eaffea;
 }
+#chat-info {
+  background-color: rgba(0, 0, 0, 0.025);
+}
 cg-board {
   background-image: url('../images/board/green.svg');
 }

--- a/play.html
+++ b/play.html
@@ -364,7 +364,7 @@
                       </div>
                       <div class="tab-pane h-100 fade" id="pills-game" role="tabpanel" aria-labelledby="pills-game-tab">
                         <div class="d-flex flex-column h-100">
-                          <div id="game-toolbar" class="d-flex justify-content-end pb-1 pt-1 pe-2" style="gap: 14px">
+                          <div id="game-toolbar" class="d-flex justify-content-end" style="gap: 14px">
                             <div class="btn-group">
                               <input type="radio" checked class="btn-check" name="view-mode" id="game-table-view" autocomplete="off">
                               <label class="btn btn-outline-secondary btn-sm" for="game-table-view" data-bs-toggle="tooltip" data-bs-placement="left" data-bs-placement-md="top" title="Table View">
@@ -402,11 +402,11 @@
                           </div>
                           <span class="center" id="game-pane-status">You're not playing a game.</span>
                           <div id="movelist-container" class="flex-grow-1 overflow-auto" style="min-height: 0">
-                            <table id="move-table" class="table table-sm">
+                            <table id="move-table" class="table table-sm mb-0">
                               <tbody></tbody>
                             </table>
                             <div id="movelists">
-                              <div class="movelist px-2 flex-wrap" style="display: flex"></div>
+                              <div class="movelist px-2 py-1 flex-wrap" style="display: flex"></div>
                             </div>
                           </div>
                         </div>
@@ -683,9 +683,9 @@
                 </span>
                 <button id="chat-toggle-btn" style="position: relative" class="btn btn-outline-secondary btn-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-chat" aria-expanded="true" title="Show/Hide Chat" aria-controls="collapse-chat">
                   <span id="chat-toggle-icon" class="fa fa-comment" aria-hidden="false"></span>
-                  <svg id="chat-unread-bubble" class="counter-bubble h-100 w-100" style="display: none; position: absolute; top: 0; left: 0">
+                  <svg id="chat-unviewed-bubble" class="counter-bubble h-100 w-100" style="display: none; position: absolute; top: 0; left: 0">
                     <circle cx="50%" cy="50%" transform="translate(6, -6)" r="6" />
-                    <text id="chat-unread-number" class="counter-number" x="50%" y="50%" transform="translate(6, -5)" text-anchor="middle" alignment-baseline="middle"></text>
+                    <text id="chat-unviewed-number" class="counter-number" x="50%" y="50%" transform="translate(6, -5)" text-anchor="middle" alignment-baseline="middle"></text>
                   </svg>
                 </button>
               </div>

--- a/play.html
+++ b/play.html
@@ -368,20 +368,20 @@
                           <div id="game-toolbar" class="d-flex justify-content-end" style="gap: 14px">
                             <div class="btn-group">
                               <input type="radio" checked class="btn-check" name="view-mode" id="game-table-view" autocomplete="off">
-                              <label class="btn btn-outline-secondary btn-sm" for="game-table-view" data-bs-toggle="tooltip" data-bs-placement="top" data-fallback-placements="left,right" title="Table View">
+                              <label class="btn btn-outline-secondary btn-sm btn-transparent" for="game-table-view" data-bs-toggle="tooltip" data-bs-placement="top" data-fallback-placements="left,right" title="Table View">
                                 <span class="fa-solid fa-table-columns" aria-hidden="false"></span>
                               </label>
                               <input type="radio" class="btn-check" name="view-mode" id="game-list-view" autocomplete="off">
-                              <label class="btn btn-outline-secondary btn-sm" for="game-list-view" data-bs-toggle="tooltip" data-bs-placement="top" data-fallback-placements="right,left" title="List View">
+                              <label class="btn btn-outline-secondary btn-sm btn-transparent" for="game-list-view" data-bs-toggle="tooltip" data-bs-placement="top" data-fallback-placements="right,left" title="List View">
                                 <span class="fa-solid fa-align-justify" aria-hidden="false"></span>
                               </label>
                             </div>
                             <input type="checkbox" class="btn-check" id="game-preserved" autocomplete="off" aria-checked="false">
-                            <label class="btn btn-outline-secondary btn-sm" for="game-preserved" data-bs-toggle="tooltip" data-bs-placement="top" title="Preserve Game" data-description="Stop this game being over-written when starting a new game.">
+                            <label class="btn btn-outline-secondary btn-sm btn-transparent" for="game-preserved" data-bs-toggle="tooltip" data-bs-placement="top" title="Preserve Game" data-description="Stop this game being over-written when starting a new game.">
                               <span class="fa-solid fa-unlock" aria-hidden="false"></span>
                             </label>
                             <div>
-                              <button type="button" id="more-game-tools" class="btn btn-outline-secondary btn-sm dropdown-toggle hide-caret position-relative" data-bs-toggle="dropdown" aria-expanded="false" aria-label="More game tools">
+                              <button type="button" id="more-game-tools" class="btn btn-outline-secondary btn-sm btn-transparent dropdown-toggle hide-caret position-relative" data-bs-toggle="dropdown" aria-expanded="false" aria-label="More game tools">
                                 <div class="tooltip-overlay" data-tooltip-hover-only data-bs-toggle="tooltip" title="More game tools"></div>
                                 <span class="fa-solid fa-ellipsis-vertical" aria-hidden="false"></span>
                               </button>
@@ -503,11 +503,11 @@
             <div class="card game-card bg-transparent">
               <div class="card-header title-bar">
                 <div class="d-flex align-items-center">
-                  <button type="button" class="me-auto btn btn-outline-secondary" title="Maximize" aria-label="Maximize">
+                  <button type="button" class="me-auto btn btn-outline-secondary btn-transparent" title="Maximize" aria-label="Maximize">
                     <span class="game-maximize-icon fa-regular fa-window-maximize" aria-hidden="false"></span>
                   </button>
                   <span m-auto class="title-bar-text"></span>
-                  <button type="button" class="ms-auto btn btn-outline-secondary" title="Close" aria-label="Close">
+                  <button type="button" class="ms-auto btn btn-outline-secondary btn-transparent" title="Close" aria-label="Close">
                     <span class="game-close-icon fa-solid fa-xmark" aria-hidden="false"></span>
                   </button>
                 </div>
@@ -557,7 +557,7 @@
               <div id="user-dropdown" class="dropdown btn-toolbar my-auto me-auto position-relative" style="max-width: 44%">
                 <button class="w-100 btn btn-outline-secondary btn-md dropdown-toggle hide-caret" type="button" id="connectButton" data-bs-toggle="dropdown" aria-label="Connect/Disconnect" aria-expanded="false">
                   <div class="tooltip-overlay" data-tooltip-hover-only data-bs-toggle="tooltip" title="Connect/Disconnect"></div>
-                  <div id="chat-status" class="w-100"></div>
+                  <div id="session-status" class="w-100"></div>
                 </button>
                 <div class="dropdown-menu" aria-labelledby="connectButton">
                   <a class="dropdown-item noselect" id="disconnect"><span class="fa fa-unlink dropdown-icon" aria-hidden="false"></span>Disconnect</a>
@@ -718,12 +718,15 @@
                         <span class="fa-solid fa-arrow-up" aria-hidden="false"></span>
                       </button>
                     </div>
-                    <br/>
                     <div class="tab-content d-flex flex-column flex-grow-1 position-relative" style="min-height: 0" id="chat-tabContent">
                       <button id="chat-scroll-button" class="btn btn-info" title="Scroll to bottom">
                         <span class="fa-solid fa-arrow-down" aria-hidden="false"></span>
                       </button>
-                      <div class="tab-pane chat-text show active" id="content-console" role="tabpanel"></div>
+                      <div class="tab-pane show active" id="content-console" role="tabpanel">
+                        <div class="d-flex flex-column chat-content-wrapper h-100">
+                          <div class="chat-text flex-grow-1 mt-3" style="min-height: 0"></div>
+                        </div>
+                      </div>
                     </div>
                   </div>
                   <div id="right-panel-footer" class="bottom-panel card-footer widget">

--- a/play.html
+++ b/play.html
@@ -693,38 +693,40 @@
             <div id="inner-right-panels">
               <div id="secondary-board-area" class="pt-1 ps-lg-2 pe-lg-1"></div>
               <div id="collapse-chat" class="collapse show collapse-init">
-                <div class="card-body d-flex flex-column" id="right-panel">
-                  <div class="d-flex">
-                    <ul class="nav nav-tabs d-flex flex-grow-1 flex-wrap justify-content-start user-select-none" role="tablist" id="tabs">
-                      <div id="chan-dropdown" class="d-flex dropdown" data-bs-toggle="tooltip" data-bs-placement="top" title="Join Channel">
-                        <button class="btn btn-outline-secondary btn-sm dropdown-toggle hide-caret" type="button" id="chanButton" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Join Channel">
-                          <span class="fa fa-plus-square" aria-hidden="false"></span>
-                        </button>
-                        <div id="chan-dropdown-menu" class="dropdown-menu" aria-labelledby="chanButton">
+                <div id="chat-panel" class="d-flex flex-column">
+                  <div class="card-body d-flex flex-column flex-grow-1" style="min-height: 0">
+                    <div class="d-flex">
+                      <ul class="nav nav-tabs d-flex flex-grow-1 flex-wrap justify-content-start user-select-none" role="tablist" id="tabs">
+                        <div id="chan-dropdown" class="d-flex dropdown" data-bs-toggle="tooltip" data-bs-placement="top" title="Join Channel">
+                          <button class="btn btn-outline-secondary btn-sm dropdown-toggle hide-caret" type="button" id="chanButton" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Join Channel">
+                            <span class="fa fa-plus-square" aria-hidden="false"></span>
+                          </button>
+                          <div id="chan-dropdown-menu" class="dropdown-menu" aria-labelledby="chanButton">
+                          </div>
                         </div>
-                      </div>
-                      <li class="nav-item">
-                        <button class="text-sm-center nav-link active" data-bs-toggle="tab" href="#content-console" id="tab-console" role="tab">Console</button>
-                      </li>
-                    </ul>
-                    <button class="align-self-start btn btn-outline-secondary btn-sm" style="display: none" type="button" id="collapse-chat-arrow" aria-label="Close Chat">
-                      <span class="fa-solid fa-arrow-up" aria-hidden="false"></span>
-                    </button>
-                  </div>
-                  <br/>
-                  <div class="tab-content d-flex flex-column flex-grow-1 position-relative" style="min-height: 0" id="chat-tabContent">
-                    <button id="chat-scroll-button" class="btn btn-info" title="Scroll to bottom">
-                      <span class="fa-solid fa-arrow-down" aria-hidden="false"></span>
-                    </button>
-                    <div class="tab-pane chat-text show active" id="content-console" role="tabpanel"></div>
-                  </div>
-                </div>
-                <div id="right-panel-footer" class="bottom-panel card-footer widget">
-                  <form id="input-form" class="form-inline d-flex h-100 w-100">
-                    <div class="input-group input-group-md m-auto">
-                      <input id="input-text" type="text" class="form-control" placeholder="Type message here and press Enter to send!" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+                        <li class="nav-item">
+                          <button class="text-sm-center nav-link active" data-bs-toggle="tab" href="#content-console" id="tab-console" role="tab">Console</button>
+                        </li>
+                      </ul>
+                      <button class="align-self-start btn btn-outline-secondary btn-sm" style="display: none" type="button" id="collapse-chat-arrow" aria-label="Close Chat">
+                        <span class="fa-solid fa-arrow-up" aria-hidden="false"></span>
+                      </button>
                     </div>
-                  </form>
+                    <br/>
+                    <div class="tab-content d-flex flex-column flex-grow-1 position-relative" style="min-height: 0" id="chat-tabContent">
+                      <button id="chat-scroll-button" class="btn btn-info" title="Scroll to bottom">
+                        <span class="fa-solid fa-arrow-down" aria-hidden="false"></span>
+                      </button>
+                      <div class="tab-pane chat-text show active" id="content-console" role="tabpanel"></div>
+                    </div>
+                  </div>
+                  <div id="right-panel-footer" class="bottom-panel card-footer widget">
+                    <form id="input-form" class="form-inline d-flex h-100 w-100">
+                      <div class="input-group input-group-md m-auto">
+                        <textarea id="input-text" rows="1" type="text" class="form-control" placeholder="Type message here and press Enter to send!" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
+                      </div>
+                    </form>
+                  </div>
                 </div>
               </div>
             </div>

--- a/play.html
+++ b/play.html
@@ -53,22 +53,23 @@
           <div class="card bg-transparent" id="left-card">
             <div class="card-header top-panel d-flex" id="left-panel-header" style="visibility: hidden">
               <div id="navigation-toolbar" class="btn-toolbar m-auto">
-                <button type="button" id="fast-backward" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-placement-md="right" title="Beginning">
+                <button type="button" id="fast-backward" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" data-fallback-placements="left,right" title="Beginning">
                   <span class="fa fa-fast-backward" aria-hidden="false"></span>
                 </button>
-                <button type="button" id="backward" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-placement-md="right" title="Back">
+                <button type="button" id="backward" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" data-fallback-placements="left,right" title="Back">
                   <span class="fa fa-backward" aria-hidden="false"></span>
                 </button>
-                <button type="button" id="forward" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-placement-md="right" title="Forward">
+                <button type="button" id="forward" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" data-fallback-placements="right,left" title="Forward">
                   <span class="fa fa-forward" aria-hidden="false"></span>
                 </button>
-                <button type="button" id="fast-forward" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-placement-md="right" title="End">
+                <button type="button" id="fast-forward" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" data-fallback-placements="right,left" title="End">
                   <span class="fa fa-fast-forward" aria-hidden="false"></span>
                 </button>
-                <button type="button" id="exit-subvariation" style="display: none" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-container="#exit-subvariation" data-bs-placement="top" data-bs-placement-md="right" title="Exit Subvariation">
+                <button type="button" id="exit-subvariation" style="display: none" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-container="#exit-subvariation" data-bs-placement="top" data-fallback-placements="right,left" title="Exit Subvariation">
                   <span class="fa fa-eject" aria-hidden="false"></span>
                 </button>
-                <button id="history-toggle-btn" class="btn btn-outline-secondary btn-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-history" title="Show/Hide Menus" aria-expanded="true" aria-controls="collapse-history">
+                <button id="history-toggle-btn" class="btn btn-outline-secondary btn-md position-relative" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-history" aria-label="Show/Hide Menus" aria-expanded="true" aria-controls="collapse-history">
+                  <div class="tooltip-overlay" data-tooltip-hover-only data-bs-toggle="tooltip" title="Show/Hide Menus"></div>
                   <span id="history-toggle-icon" class="fa fa-toggle-up" aria-hidden="false"></span>
                 </button>
               </div>
@@ -367,20 +368,21 @@
                           <div id="game-toolbar" class="d-flex justify-content-end" style="gap: 14px">
                             <div class="btn-group">
                               <input type="radio" checked class="btn-check" name="view-mode" id="game-table-view" autocomplete="off">
-                              <label class="btn btn-outline-secondary btn-sm" for="game-table-view" data-bs-toggle="tooltip" data-bs-placement="left" data-bs-placement-md="top" title="Table View">
+                              <label class="btn btn-outline-secondary btn-sm" for="game-table-view" data-bs-toggle="tooltip" data-bs-placement="top" data-fallback-placements="left,right" title="Table View">
                                 <span class="fa-solid fa-table-columns" aria-hidden="false"></span>
                               </label>
                               <input type="radio" class="btn-check" name="view-mode" id="game-list-view" autocomplete="off">
-                              <label class="btn btn-outline-secondary btn-sm" for="game-list-view" data-bs-toggle="tooltip" data-bs-placement="top" title="List View">
+                              <label class="btn btn-outline-secondary btn-sm" for="game-list-view" data-bs-toggle="tooltip" data-bs-placement="top" data-fallback-placements="right,left" title="List View">
                                 <span class="fa-solid fa-align-justify" aria-hidden="false"></span>
                               </label>
                             </div>
                             <input type="checkbox" class="btn-check" id="game-preserved" autocomplete="off" aria-checked="false">
-                            <label class="btn btn-outline-secondary btn-sm" for="game-preserved" data-bs-toggle="tooltip" data-bs-placement="top" title="Preserve Game">
+                            <label class="btn btn-outline-secondary btn-sm" for="game-preserved" data-bs-toggle="tooltip" data-bs-placement="top" title="Preserve Game" data-description="Stop this game being over-written when starting a new game.">
                               <span class="fa-solid fa-unlock" aria-hidden="false"></span>
                             </label>
                             <div>
-                              <button type="button" id="more-game-tools" class="btn btn-outline-secondary btn-sm dropdown-toggle hide-caret" data-bs-toggle="dropdown" aria-expanded="false" title="More tools">
+                              <button type="button" id="more-game-tools" class="btn btn-outline-secondary btn-sm dropdown-toggle hide-caret position-relative" data-bs-toggle="dropdown" aria-expanded="false" aria-label="More game tools">
+                                <div class="tooltip-overlay" data-tooltip-hover-only data-bs-toggle="tooltip" title="More game tools"></div>
                                 <span class="fa-solid fa-ellipsis-vertical" aria-hidden="false"></span>
                               </button>
                               <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="more-game-tools">
@@ -551,8 +553,9 @@
         <div id="right-col" class="col-sm-12 col-md-12 col-lg position-relative align-self-center" style="min-width: 360px">
           <div class="card bg-transparent" id="right-card">
             <div class="top-panel card-header" id="right-panel-header" style="visibility: hidden">
-              <div id="user-dropdown" class="dropdown btn-toolbar my-auto me-auto" style="max-width: 44%">
-                <button class="w-100 btn btn-outline-secondary btn-md dropdown-toggle hide-caret" type="button" id="connectButton" data-bs-toggle="dropdown" title="Connect/Disconnect" aria-expanded="false" title="User">
+              <div id="user-dropdown" class="dropdown btn-toolbar my-auto me-auto position-relative" style="max-width: 44%">
+                <button class="w-100 btn btn-outline-secondary btn-md dropdown-toggle hide-caret" type="button" id="connectButton" data-bs-toggle="dropdown" aria-label="Connect/Disconnect" aria-expanded="false">
+                  <div class="tooltip-overlay" data-tooltip-hover-only data-bs-toggle="tooltip" title="Connect/Disconnect"></div>
                   <div id="chat-status" class="w-100"></div>
                 </button>
                 <div class="dropdown-menu" aria-labelledby="connectButton">
@@ -562,7 +565,8 @@
                 </div>
               </div>
               <div class="btn-toolbar my-auto ms-auto">
-                <button id="chat-maximize-btn" class="btn btn-outline-secondary btn-md" type="button" title="Maximize Chat">
+                <button id="chat-maximize-btn" class="btn btn-outline-secondary btn-md position-relative" type="button" aria-label="Maximize Chat">
+                  <div class="tooltip-overlay" data-tooltip-hover-only data-bs-toggle="tooltip" data-fallback-placements="left, right" title="Maximize Chat"></div>
                   <span id="chat-maximize-icon" class="fa fa-toggle-left" aria-hidden="false"></span>
                 </button>
                 <div class="modal fade" id="settings-modal" tabindex="-1" aria-labelledby="settings-modal-label" aria-hidden="true">
@@ -681,7 +685,8 @@
                   </button>
                   <span></span> <!-- This tricks bootstrap into allowing the outer <span> wrapper in a btn-toolbar (so we can have a tooltip on a disabled button) -->
                 </span>
-                <button id="chat-toggle-btn" style="position: relative" class="btn btn-outline-secondary btn-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-chat" aria-expanded="true" title="Show/Hide Chat" aria-controls="collapse-chat">
+                <button id="chat-toggle-btn" style="position: relative" class="btn btn-outline-secondary btn-md" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-chat" aria-expanded="true" aria-label="Show/Hide Chat" aria-controls="collapse-chat">
+                  <div class="tooltip-overlay" data-tooltip-hover-only data-bs-toggle="tooltip" title="Show/Hide Chat"></div>
                   <span id="chat-toggle-icon" class="fa fa-comment" aria-hidden="false"></span>
                   <svg id="chat-unviewed-bubble" class="counter-bubble h-100 w-100" style="display: none; position: absolute; top: 0; left: 0">
                     <circle cx="50%" cy="50%" transform="translate(6, -6)" r="6" />

--- a/play.html
+++ b/play.html
@@ -530,7 +530,7 @@
               <div class="card-body p-0 noselect" id="board-card">
                 <div class="mw-100 position-relative">
                   <div class="promotion-panel"></div>
-                  <div class="cg-wrap mw-100 board"></div>
+                  <div class="cg-wrap mw-100 board overflow-hidden"></div>
                 </div>
               </div>
               <div class="bottom-panel card-footer p-0">
@@ -699,7 +699,7 @@
             <div id="inner-right-panels">
               <div id="secondary-board-area" class="pt-1 ps-lg-2 pe-lg-1"></div>
               <div id="collapse-chat" class="collapse show collapse-init">
-                <div id="chat-panel" class="d-flex flex-column">
+                <div id="chat-panel" class="flex-column">
                   <div class="card-body d-flex flex-column flex-grow-1" style="min-height: 0">
                     <div class="d-flex">
                       <ul class="nav nav-tabs d-flex flex-grow-1 flex-wrap justify-content-start user-select-none" role="tablist" id="tabs">

--- a/play.html
+++ b/play.html
@@ -502,10 +502,11 @@
           <div id="main-board-area">
             <div class="card game-card bg-transparent">
               <div class="card-header title-bar">
-                <div class="d-flex">
+                <div class="d-flex align-items-center">
                   <button type="button" class="me-auto btn btn-outline-secondary" title="Maximize" aria-label="Maximize">
                     <span class="game-maximize-icon fa-regular fa-window-maximize" aria-hidden="false"></span>
                   </button>
+                  <span m-auto class="title-bar-text"></span>
                   <button type="button" class="ms-auto btn btn-outline-secondary" title="Close" aria-label="Close">
                     <span class="game-close-icon fa-solid fa-xmark" aria-hidden="false"></span>
                   </button>

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -121,6 +121,7 @@ export class Chat {
       if(this.scrolledToBottom[contentPane.attr('id')]) 
         contentPane.scrollTop(contentPane[0].scrollHeight);
       contentPane.trigger('scroll');
+      
     });
 
     $('#chat-scroll-button').on('click', (e) => {
@@ -368,7 +369,7 @@ export class Chat {
 function scrollToChat() {
   if(isSmallWindow()) {
     if($('#secondary-board-area').is(':visible'))
-      $(document).scrollTop($('#right-panel').offset().top);
+      $(document).scrollTop($('#chat-panel').offset().top);
     else
       $(document).scrollTop($('#right-panel-header').offset().top);
   }

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -199,7 +199,10 @@ export class Chat {
   }
 
   public createTab(name: string, showTab = false) {
-    var from = name.toLowerCase().replace(/\s/g, '-');
+    if(!chattabsToggle)
+      var from = "console";
+    else
+      var from = name.toLowerCase().replace(/\s/g, '-');
 
     // Check whether this is a bughouse chat tab, e.g. 'Game 23 and 42'
     var match = from.match(/^game-(\d+)/);
@@ -395,6 +398,28 @@ export class Chat {
       var currentTab = 'console';
 
     this.newMessage(currentTab, {message: msg}, true);
+  }
+
+  public closeUnusedPrivateTabs() {
+    $('#tabs .nav-link').each((index, element) => {
+      var id = $(element).attr('id');
+      if(id !== 'tab-console' && !/^tab-(game-|\d+)/.test(id)) {
+        var chatText = $($(element).attr('href')).find('.chat-text');
+        if(chatText.html() === '')
+          this.closeTab($(element))
+      }
+    });
+  }
+
+  public closeGameTab(gameId: number) {
+    if(gameId == null || gameId === -1)
+      return;
+
+    $('#tabs .nav-link').each((index, element) => {
+      var match = $(element).attr('id').match(/^tab-game-(\d+)(?:-|$)/);
+      if(match && match.length > 1 && +match[1] === gameId) 
+        this.closeTab($(element));
+    });
   }
 }
 

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -199,7 +199,23 @@ export class Chat {
   }
 
   public createTab(name: string, showTab = false) {
-    const from = name.toLowerCase().replace(/\s/g, '-');
+    var from = name.toLowerCase().replace(/\s/g, '-');
+
+    // Check whether this is a bughouse chat tab, e.g. 'Game 23 and 42'
+    var match = from.match(/^game-(\d+)/);
+    if(match && match.length > 1) {
+      var gameId = match[1];
+      for(let key in this.tabs) {
+        if(this.tabs.hasOwnProperty(key)) {
+          match = key.match(/^game-(\d+)-and-(\d+)/)
+          if(match && match.length > 2 && (match[1] === gameId || match[2] === gameId)) {
+            from = key;
+            break;
+          }
+        }
+      }
+    }
+
     if (!this.tabs.hasOwnProperty(from)) {
       let chName = name;
       if (channels[name] !== undefined) {
@@ -207,7 +223,7 @@ export class Chat {
       }
 
       if(!$('#tabs').find('#tab-' + from).length) {
-        var match = chName.match(/Game (\d+)/);
+        var match = chName.match(/^Game (\d+)/);
         var tooltip = '';
         if(match && match.length > 1) {
           var game = findGame(+match[1]);
@@ -233,6 +249,7 @@ export class Chat {
       this.tabs[from] = $('#content-' + from);
       this.scrolledToBottom['content-' + from] = true;
 
+      // Scroll event listener for auto scroll to bottom etc
       var lastWidth, lastHeight;
       $('#content-' + from).on('scroll', (e) => {
         var tab = e.target;

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -121,7 +121,6 @@ export class Chat {
       if(this.scrolledToBottom[contentPane.attr('id')]) 
         contentPane.scrollTop(contentPane[0].scrollHeight);
       contentPane.trigger('scroll');
-      
     });
 
     $('#chat-scroll-button').on('click', (e) => {
@@ -282,9 +281,8 @@ export class Chat {
   }
 
   private escapeHTML(text: string) {
-    return text.replace(/[&<>"]/g, (tag) => {
+    return text.replace(/[<>"]/g, (tag) => {
       var charsToReplace = {
-          '&': '&amp;',
           '<': '&lt;',
           '>': '&gt;',
           '"': '&#34;'
@@ -295,6 +293,10 @@ export class Chat {
 
   public newMessage(from: string, data: any, html: boolean = false) {
     let tabName = chattabsToggle ? from : 'console';
+
+    if(!/^[\w- ]+$/.test(from)) 
+      return;
+
     const tab = this.createTab(tabName);
     let who = '';
     if (data.user !== undefined) {

--- a/src/game.ts
+++ b/src/game.ts
@@ -58,7 +58,8 @@ export class Game extends GameData {
   history: any = null;
   clock: any = null;
   board: any = null;
-  watchers: any = null;
+  watchers: any = [];
+  watchersInterval: any = null;
   captured: any = {};
 
   // HTML elements associated with this Game

--- a/src/history.ts
+++ b/src/history.ts
@@ -810,10 +810,10 @@ export class History {
       const scrollBot = childRect.bottom - parentRect.bottom;
       if (Math.abs(scrollTop) < Math.abs(scrollBot)) {
         // we're near the top of the list
-        parent.scrollTop += scrollTop;
+        parent.scrollTop += scrollTop - 4;
       } else {
         // we're near the bottom of the list
-        parent.scrollTop += scrollBot;
+        parent.scrollTop += scrollBot + 4;
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ let isRegistered = false;
 let lastComputerGame = null; // Attributes of the last game played against the Computer. Used for Rematch and alternating colors each game.
 let gameWithFocus: Game = null;
 let games: Game[] = []; 
-let partnerGameId;
+let partnerGameId = null;
 
 const mainBoard: any = createBoard($('#main-board-area').children().first().find('.board'));
 
@@ -139,6 +139,7 @@ function cleanupGame(game: Game) {
 }
 
 export function cleanup() {
+  partnerGameId = null;
   historyRequested = 0;
   obsRequested = 0;
   allobsRequested = 0;
@@ -1673,9 +1674,10 @@ function gameStart(game: Game) {
       else {            
         $('#play-computer').prop('disabled', true);    
         
-        if(game.category === 'bughouse') {
+        if(game.category === 'bughouse' && partnerGameId !== null) {
           game.partnerGameId = partnerGameId;
-          chat.createTab('Game ' + game.id);
+          chat.createTab('Game ' + game.id + ' and ' + partnerGameId);
+          partnerGameId = null;
         }
         else if(game.color === 'w') 
           chat.createTab(game.bname);
@@ -2353,8 +2355,10 @@ function messageHandler(data) {
 
         partnerGameId = +match[1];
         var mainGame = getPlayingExaminingGame();
-        if(mainGame) 
+        if(mainGame) {
           mainGame.partnerGameId = partnerGameId;
+          chat.createTab('Game ' + mainGame.id + ' and ' + partnerGameId);
+        }
       }
 
       match = msg.match(/^(Creating|Game\s(\d+)): (\w+) \(([\d\+\-\s]+)\) (\w+) \(([\d\-\+\s]+)\) \S+ (\S+).+/m);

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,9 @@ function cleanupGame(game: Game) {
   }
 
   game.element.find($('[title="Close"]')).show();
-
+  
+  if(chat)
+    chat.closeGameTab(game.id);
   hidePromotionPanel(game);
   game.clock.stopClocks();
 
@@ -1658,6 +1660,28 @@ function gameStart(game: Game) {
     updateBoard(game);
   }
 
+  // Close old unused private chat tabs
+  chat.closeUnusedPrivateTabs();
+  // Open chat tabs
+  if(game.isPlayingOnline()) {
+    if(game.category === 'bughouse' && partnerGameId !== null) 
+      chat.createTab('Game ' + game.id + ' and ' + partnerGameId); // Open chat room for all bughouse participants
+    else if(game.color === 'w') 
+      chat.createTab(game.bname);
+    else 
+      chat.createTab(game.wname);  
+  }
+  else if(game.isObserving() || game.isExamining()) {
+    if(mainGame && game.id === mainGame.partnerGameId) { // Open chat to bughouse partner
+      if(game.color === 'w') 
+        chat.createTab(game.wname);
+      else 
+        chat.createTab(game.bname);
+    }
+    else 
+      chat.createTab('Game ' + game.id);    
+  }
+
   if(game.isPlaying() || game.isObserving()) {
     // Adjust settings for game category (variant)
     // When examining we do this after requesting the movelist (since the category is told to us by the 'moves' command)
@@ -1673,24 +1697,11 @@ function gameStart(game: Game) {
       } 
       else {            
         $('#play-computer').prop('disabled', true);    
-        
         if(game.category === 'bughouse' && partnerGameId !== null) {
           game.partnerGameId = partnerGameId;
-          chat.createTab('Game ' + game.id + ' and ' + partnerGameId);
           partnerGameId = null;
         }
-        else if(game.color === 'w') 
-          chat.createTab(game.bname);
-        else 
-          chat.createTab(game.wname);  
       }
-    }
-
-    if(mainGame && game.id === mainGame.partnerGameId) {
-      if(game.color === 'w') 
-        chat.createTab(game.wname);
-      else 
-        chat.createTab(game.bname);
     }
   }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -379,12 +379,19 @@ export class Parser {
     }
 
     // kibitz/whispers
-    match = msg.match(/(?:^|\n)([a-zA-Z]+)(?:\([A-Z0-9\*\-]+\))*\[([0-9]+)\] (?:kibitzes|whispers):\s+([\s\S]*)/s);
-    if (match != null && match.length > 3) {
+    match = msg.match(/(?:^|\n)([a-zA-Z]+)(?:\([A-Z0-9\*\-]+\))*\[([0-9]+)\] (kibitzes|whispers):\s+(.*)(?:\n(.+))?/);
+    if (match != null && match.length > 4) {
+      if(match[3] === 'kibitzes')
+        var type = 'kibitz';
+      else
+        var type = 'whisper';
+      
       return {
         channel: 'Game ' + match[2],
         user: match[1],
-        message: match[3].replace(/\n/g, ''),
+        type: type,
+        message: match[4].replace(/\n/g, ''),
+        suffix: match[5]
       };
     }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -48,8 +48,8 @@ export class Session {
   private tsKey = 'Timestamp (FICS) v1.0 - programmed by Henrik Gram.';
   private parser: Parser;
   private registered: boolean;
-  private chatStatusPopoverTimer; // Hide chat status popover after duration
-  private bodyClickHandler; // Used to detect when user clicks outside of chat status popover
+  private sessionStatusPopoverTimer; // Hide session status popover after duration
+  private bodyClickHandler; // Used to detect when user clicks outside of session status popover
 
   constructor(onRecv: (msg: any) => void, user?: string, pass?: string) {
     this.connected = false;
@@ -60,11 +60,11 @@ export class Session {
 
     // Hide popover if user clicks anywhere outside
     this.bodyClickHandler = (e) => {
-      if(!$('#chat-status').is(e.target) 
-          && $('#chat-status').has(e.target).length === 0
+      if(!$('#session-status').is(e.target) 
+          && $('#session-status').has(e.target).length === 0
           && $('.popover').has(e.target).length === 0)
-        $('#chat-status').popover('dispose');
-        clearTimeout(this.chatStatusPopoverTimer);
+        $('#session-status').popover('dispose');
+        clearTimeout(this.sessionStatusPopoverTimer);
     };
     $('body').on('click', this.bodyClickHandler);
   }
@@ -90,15 +90,15 @@ export class Session {
   }
 
   public setUser(user: string): void {
-    $('#chat-status').html('<span style="overflow: hidden; text-overflow: ellipsis"><span class="fa fa-circle" aria-hidden="false"></span>&nbsp;<span class="h6">' + user + '</span></span>');
+    $('#session-status').html('<span style="overflow: hidden; text-overflow: ellipsis"><span class="fa fa-circle" aria-hidden="false"></span>&nbsp;<span class="h6">' + user + '</span></span>');
     if(!this.user) { // Only display popover if this is a new user or guest
-      $('#chat-status').popover({
+      $('#session-status').popover({
         animation: true,
         content: 'Connected as ' + user + '. Click here to connect as a different user!',
         placement: 'top',
       });
-      $('#chat-status').popover('show');
-      this.chatStatusPopoverTimer = setTimeout(() => $('#chat-status').popover('dispose'), 3600);
+      $('#session-status').popover('show');
+      this.sessionStatusPopoverTimer = setTimeout(() => $('#session-status').popover('dispose'), 3600);
     }
     this.connected = true;
     this.user = user;
@@ -110,7 +110,7 @@ export class Session {
 
   public connect(user?: string, pass?: string) {
     $('#game-requests').empty();
-    $('#chat-status').html('<span class="text-warning"><span class="spinner-grow spinner-grow-sm" role="status" aria-hidden="true"></span>&nbsp;Connecting...</span>');
+    $('#session-status').html('<span class="text-warning"><span class="spinner-grow spinner-grow-sm" role="status" aria-hidden="true"></span>&nbsp;Connecting...</span>');
     const login = (user !== undefined && pass !== undefined);
     let loginOptions = '';
     let text = '';
@@ -137,19 +137,19 @@ export class Session {
     const that = this;
     this.websocket.onclose = function(e) { that.reset(e); };
     this.websocket.onopen = () => {
-      $('#chat-status').html('<span class="text-warning"><span class="spinner-grow spinner-grow-sm" role="status" aria-hidden="true"></span>&nbsp;Connecting...</span>');
+      $('#session-status').html('<span class="text-warning"><span class="spinner-grow spinner-grow-sm" role="status" aria-hidden="true"></span>&nbsp;Connecting...</span>');
       this.send(this.timesealHello);
     };
   }
 
   public disconnect() {
-    $('#chat-status').html('<span class="text-danger"><span class="spinner-grow spinner-grow-sm" role="status" aria-hidden="true"></span>&nbsp;Disconnecting...</span>');
+    $('#session-status').html('<span class="text-danger"><span class="spinner-grow spinner-grow-sm" role="status" aria-hidden="true"></span>&nbsp;Disconnecting...</span>');
     this.websocket.close();
     this.reset(undefined);
   }
 
   public reset(_e: any) {
-    $('#chat-status').html('<span class="text-danger"><span class="fa fa-circle" aria-hidden="false"></span>&nbsp;Offline</span>');
+    $('#session-status').html('<span class="text-danger"><span class="fa fa-circle" aria-hidden="false"></span>&nbsp;Offline</span>');
     this.connected = false;
     this.user = '';
     disableOnlineInputs(true);


### PR DESCRIPTION
Made some changes to make games and their corresponding chat tabs easier to identify:
- Added the game's ID to the status panel and the title bar for small boards. The ID is removed again when you stop Observing/Examining the game.
- When you hover a game's chat tab, it shows a tooltip with the names of the players 
- Added an info-bar to the top of Game chat tabs, which shows the players and their ratings and also the number of watchers.
- When you click on the game description in the info-bar it maximizes the corresponding game board.
- When you hover the mouse over the number of watchers, it pops up a tooltip that contains the list of all watchers, see screenshot below.
https://www.flickr.com/gp/197116004@N06/FaW6dC7G32

Automatically create and remove chat tabs:
- Now the coresponding chat tab is automatically opened when you Observe/Examine a game, and is removed again when you Unobserve/Unexamine the game. 
- Also opponent chat tabs (which are automatically opened when starting a new game) are now cleaned up when they are no longer needed. Specifically, when you start your next game, any previous private tell chat tabs which are completely empty are closed. Chat tabs containing text are not closed. 

Multi-line* textarea:
- As shown previously, the text-input is now a text-area which expands when the text wraps. The amount of text the user can enter has also been limited to 1023 characters when in the console or when using @ to enter a command and 400 characters when in a chat tab (200 for Guests). This is to correspond with FICS limits, so the user can never enter a message which is too long. 
I was thinking in a future update we might consider allowing <br> tags in tells, then the textarea could be changed to allow true multi-line messages

Chat command truncating and splitting and unicode support:
- Also when using a chat command like tell, whisper etc in the console, the message portion of the command will be truncated to 400 characters and then sent. 
- I added unicode support where tells are first truncated to 400 unicode characters, then  HTML encoded, then the resulting ASCII message is split into multiple 400 character tells and sent. This allows foreign language people to still send 400  unicode characters at once.

Tooltips revamp:
- Added support for "descriptive" tool-tips. These have a title in bold, then a seperator, followed by a longer description. See screenshot below. To create one you add the attribute data-description="some text" to the tooltip triggering element. 

https://flic.kr/p/2pVLeTt

- Changed the way tooltips are placed on mobile etc. I used to have different tooltip placements for mobile and desktop, but I realise this was not the right way to do it. Instead bootstrap supports "fallback placements", where you can specify where to place the tooltip if there is no room for the first choice. So I changed it over to use these.
-  Added support for 'hover-only' tooltips, which don't display when you click a button, but only when you hover over it with a  mouse. These are specified by putting the 'data-tooltip-hover-only' attribute on the button. 
- Found a way to add bootstrap tooltips to the collapsable and dropdown buttons. I made an overlay element with position: absolute which is positioned over the top of the button, and attach the tooltip to it.  

Lastly added a suffix to whispers in chat tabs to differentiate them from kibitzes.

Let me know if you have any issues or thoughts on these. 

Future todo ideas I was pondering:
- Integrate messages into the chat tabs. Basically how this would work, is when the user logs on, a notification appers telling them they have X unread messages and asking if they would like to display them in chat tabs. Then it would create a separate chat tab for each sender. Secondly when the user tries to send a tell to someone who is offline, a dialog would appear asking if they want to send it as a message.
- Add an Adjourn button next to Abort, Resign etc. Perhaps only display this button for standard time controls or slower.
- Add chess piece unicode icons to move list (as discussed)
- Add a text input to the top of the '+' Join Channel button which lets the user type in a person's name and open a chat tab to them. 
- Also add a 'more channels...' button to the Join Channel dropdown which opens a dialog that lets the person subscribe/unsubscribe (+ch/-ch) to more channels. 
- Add a Stats button to the top-right toolbar next to Settings. This would display finger stats and possibly from other commands, except with prettier styling. 
- Add a Tournaments tab to the Play pane, which lets the person easily join upcoming tournaments.
- In settings, have separate settings for board color and theme, so the user can customize the board specifically.

And I want to go back to working on the move list, and making it so the user can eventually annotate and save PGNs properly.  
