### PR TITLE
Service worker fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "app": "tsc src/app.ts && node src/copy-app-files.js && electron src/app.js",
     "lint": "eslint -c .eslintrc.js --ext .ts src",
-    "bundle": "webpack --mode production && node src/inject-manifest.js",
+    "bundle": "webpack --mode production",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",
     "build": "node src/copy-app-files.js && electron-builder -mwl --x64 --arm64 -p always",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack');
+const { exec } = require('child_process');
 
 module.exports = [{
     name: 'bundle',
@@ -74,4 +75,16 @@ module.exports = [{
         filename: 'service-worker.js',
         path: __dirname,
     },
+    plugins: [
+        {
+            apply: (compiler) => {
+                compiler.hooks.done.tap('RunAfterBuildPlugin', () => {
+                    exec(`node "${__dirname}/src/inject-manifest.js"`, (err, stdout, stderr) => {
+                        if (stdout) console.log(stdout);
+                        if (stderr) console.error(stderr);
+                    });
+                });
+            }
+        }
+    ]
 }]


### PR DESCRIPTION
I noticed there was an error in the debug console on freechess.club:
```
Uncaught TypeError: self.__WB_MANIFEST is not iterable
    at service-worker.js?env=web:1:17001
```
This implies that inject-manifest.js wasn't called during the build process (therefore the service-worker.js is incomplete and won't cache anything.)

This is because I'd wrongly assumed that you would always use 'npm run bundle' in order to run webpack and I was running inject-manifest.js in that command. 

Therefore I've changed it now so that webpack.config.js will run inject-manifest.js directly.
This should fix the error  

Sorry for the inconenience. 

