### PR TITLE
Fix bishop square color calc

### DIFF
--- a/src/chess-helper.ts
+++ b/src/chess-helper.ts
@@ -139,7 +139,7 @@ export function insufficientMaterial(fen: string, variantData?: VariantData, col
       if(piece.type === 'b') {
         const fileNum = sq[0].charCodeAt(0) - 'a'.charCodeAt(0) + 1;
         const rankNum = +sq[1];
-        const squareColor = fileNum + rankNum % 2 ? 'w' : 'b';
+        const squareColor = (fileNum + rankNum) % 2 === 0 ? 'b' : 'w';
         material[`${pieceColorType}${squareColor}`] = 1;
       }
       else


### PR DESCRIPTION
## Summary
- fix color detection for bishops when determining insufficient material

## Testing
- `yarn lint` *(fails: package missing from lockfile)*
- `yarn install` *(fails: unable to fetch dependencies due to SSH restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6843b1468ec0832b896c3af1111a1368