### PR TITLE
Add experimental chat hiding options

### DIFF
--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -906,5 +906,42 @@ input[type="number"]:focus {
   font-weight: bold;
 }
 .banner-alert.show {
-  transform: translateY(0); 
+  transform: translateY(0);
+}
+
+/* Option 1: hide right column when chat is collapsed */
+@media (min-width: 992px) {
+  #right-col.chat-hidden {
+    display: none !important;
+  }
+}
+
+/* Option 2: overlay chat panel */
+.chat-overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 374px;
+  max-width: 100%;
+  overflow-y: auto;
+  background-color: var(--bs-body-bg);
+  z-index: 1055;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+}
+
+@media (max-width: 767px) {
+  .chat-overlay {
+    width: 100%;
+  }
+}
+
+.chat-overlay-backdrop {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1050;
 }

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -134,6 +134,12 @@ const emoticons = {
 
 let maximized = false;
 
+// Option toggles for experimenting with chat display
+// When true, the right column will be hidden when chat is collapsed
+const HIDE_CHAT_COLUMN_ON_COLLAPSE = false;
+// When true, chat is shown as an overlay instead of occupying a column
+const USE_CHAT_OVERLAY = false;
+
 export class Chat {
   private user: string;
   private userRE: RegExp;
@@ -155,6 +161,11 @@ export class Chat {
     settings.timestampToggle = (storage.get('timestamp') !== 'false');
     settings.chattabsToggle = (storage.get('chattabs') !== 'false');
     this.virtualScrollerPromise = import('virtual-scroller/dom');
+
+    if(USE_CHAT_OVERLAY) {
+      $('#collapse-chat').addClass('chat-overlay');
+      $('#right-col').addClass('chat-hidden');
+    }
 
     // initialize tabs
     this.tabData = {};
@@ -196,6 +207,10 @@ export class Chat {
       if(!$('#collapse-chat').hasClass('collapse-init'))
         scrollToBoard();
       $('#collapse-chat').removeClass('collapse-init');
+      if(HIDE_CHAT_COLUMN_ON_COLLAPSE && !$('#secondary-board-area').children().length)
+        $('#right-col').addClass('chat-hidden');
+      if(USE_CHAT_OVERLAY)
+        $('#chat-overlay-backdrop').remove();
     });
 
     $('#collapse-chat').on('shown.bs.collapse', () => {
@@ -203,6 +218,14 @@ export class Chat {
       activeTab.trigger('shown.bs.tab');
       $(window).trigger('resize');
       this.scrollToChat();
+      if(HIDE_CHAT_COLUMN_ON_COLLAPSE || USE_CHAT_OVERLAY)
+        $('#right-col').removeClass('chat-hidden');
+      if(USE_CHAT_OVERLAY) {
+        if(!$('#chat-overlay-backdrop').length)
+          $('<div id="chat-overlay-backdrop" class="chat-overlay-backdrop"></div>')
+            .appendTo('body')
+            .on('click', () => $('#collapse-chat').collapse('hide'));
+      }
     });
 
     $('#collapse-chat').on('show.bs.collapse', () => {
@@ -211,6 +234,8 @@ export class Chat {
 
     $('#collapse-chat').on('hide.bs.collapse', () => {
       $('#chat-toggle-btn').removeClass('toggle-btn-selected');
+      if(USE_CHAT_OVERLAY)
+        $('#chat-overlay-backdrop').remove();
     });
 
     $('#collapse-chat-arrow').on('click', () => {


### PR DESCRIPTION
## Summary
- implement optional chat display features: hide column on collapse or overlay
- add supporting CSS styles

## Testing
- `yarn lint` *(fails: 196 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a32ae896c832bbdb04dffaad0668b