### PR TITLE
Add chat column hiding and overlay options

### DIFF
--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -165,38 +165,30 @@ body {
   transform: translateX(-50%);
 }
 
-#chat-restore-btn {
-  display: none;
+body.chat-hidden #right-col {
   position: fixed;
   right: 0;
   top: 50%;
-  transform: translateY(-50%);
+  transform: translateY(-50%) rotate(-90deg);
+  transform-origin: top right;
+  min-width: 40px !important;
+  width: 40px;
   z-index: 1040;
 }
 
-body.chat-hidden #right-col {
-  min-width: 40px !important;
-  width: 40px;
-}
-
-body.chat-hidden #chat-restore-btn {
-  display: flex;
-  width: 80px;
-  height: 40px;
-  justify-content: center;
-  align-items: center;
-  border-radius: 0.375rem 0 0.375rem 0;
-  transform: translateY(-50%) rotate(-90deg);
-  transform-origin: center;
-}
-
-body.chat-hidden #chat-restore-btn .fa {
+body.chat-hidden #chat-toggle-btn {
   transform: rotate(90deg);
 }
 
 #right-col.chat-collapsed {
+  position: fixed;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%) rotate(-90deg);
+  transform-origin: top right;
   min-width: 40px !important;
   width: 40px;
+  z-index: 1040;
 }
 
 @media (min-width: 768px) {

--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -165,6 +165,14 @@ body {
   transform: translateX(-50%);
 }
 
+#chat-restore-btn {
+  display: none;
+  position: fixed;
+  right: 12px;
+  bottom: 12px;
+  z-index: 1040;
+}
+
 #fake-input-text:focus-within {
   color: #212529;
   background-color: #fff;

--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -173,6 +173,13 @@ body {
   z-index: 1040;
 }
 
+@media (min-width: 768px) {
+  body.chat-hidden #left-col {
+    width: 33%;
+    margin-right: 1rem;
+  }
+}
+
 #fake-input-text:focus-within {
   color: #212529;
   background-color: #fff;

--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -181,15 +181,17 @@ body.chat-hidden #right-col {
 
 body.chat-hidden #chat-restore-btn {
   display: flex;
-  width: 40px;
-  height: 80px;
+  width: 80px;
+  height: 40px;
   justify-content: center;
   align-items: center;
-  border-radius: 0.375rem 0 0 0.375rem;
+  border-radius: 0.375rem 0 0.375rem 0;
+  transform: translateY(-50%) rotate(-90deg);
+  transform-origin: center;
 }
 
 body.chat-hidden #chat-restore-btn .fa {
-  transform: rotate(-90deg);
+  transform: rotate(90deg);
 }
 
 #right-col.chat-collapsed {

--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -165,45 +165,34 @@ body {
   transform: translateX(-50%);
 }
 
-body.chat-hidden #right-col {
-  position: fixed;
-  right: 0;
-  top: 50%;
-  width: 100vh;
-  height: 40px;
-  min-width: 0 !important;
-  transform: translateY(-50%) rotate(-90deg);
-  transform-origin: top right;
-  overflow: hidden;
-  z-index: 1040;
-}
-
-body.chat-hidden #chat-toggle-btn {
-  transform: rotate(90deg);
-}
-
-body.chat-hidden #right-card,
-#right-col.chat-collapsed #right-card {
-  display: none;
-}
-
-#right-col.chat-collapsed {
-  position: fixed;
-  right: 0;
-  top: 50%;
-  width: 100vh;
-  height: 40px;
-  min-width: 0 !important;
-  transform: translateY(-50%) rotate(-90deg);
-  transform-origin: top right;
-  overflow: hidden;
-  z-index: 1040;
+#right-col {
+  min-width: 374px;
 }
 
 @media (min-width: 768px) {
+  body.chat-hidden #right-col {
+    position: fixed !important;
+    top: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: auto;
+    z-index: 1000;
+  }
+  body.chat-hidden #main-row {
+    padding-top: var(--right-col-height, 3.5rem);
+  }
   body.chat-hidden #left-col {
-    width: 33%;
-    margin-right: 1rem;
+    width: 50%;
+    flex-shrink: 0;
+    padding-left: 2rem;
+    padding-right: 1rem;
+  }
+  body.chat-hidden #mid-col {
+    width: 50%;
+    flex-shrink: 0;
+    padding-left: 1rem;
+    padding-right: 2rem;
   }
 }
 

--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -168,9 +168,33 @@ body {
 #chat-restore-btn {
   display: none;
   position: fixed;
-  right: 12px;
-  bottom: 12px;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
   z-index: 1040;
+}
+
+body.chat-hidden #right-col {
+  min-width: 40px !important;
+  width: 40px;
+}
+
+body.chat-hidden #chat-restore-btn {
+  display: flex;
+  width: 40px;
+  height: 80px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 0.375rem 0 0 0.375rem;
+}
+
+body.chat-hidden #chat-restore-btn .fa {
+  transform: rotate(-90deg);
+}
+
+#right-col.chat-collapsed {
+  min-width: 40px !important;
+  width: 40px;
 }
 
 @media (min-width: 768px) {

--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -169,10 +169,12 @@ body.chat-hidden #right-col {
   position: fixed;
   right: 0;
   top: 50%;
+  width: 100vh;
+  height: 40px;
+  min-width: 0 !important;
   transform: translateY(-50%) rotate(-90deg);
   transform-origin: top right;
-  min-width: 40px !important;
-  width: 40px;
+  overflow: hidden;
   z-index: 1040;
 }
 
@@ -180,14 +182,21 @@ body.chat-hidden #chat-toggle-btn {
   transform: rotate(90deg);
 }
 
+body.chat-hidden #right-card,
+#right-col.chat-collapsed #right-card {
+  display: none;
+}
+
 #right-col.chat-collapsed {
   position: fixed;
   right: 0;
   top: 50%;
+  width: 100vh;
+  height: 40px;
+  min-width: 0 !important;
   transform: translateY(-50%) rotate(-90deg);
   transform-origin: top right;
-  min-width: 40px !important;
-  width: 40px;
+  overflow: hidden;
   z-index: 1040;
 }
 

--- a/play.html
+++ b/play.html
@@ -728,7 +728,7 @@
             </div>
           </div>
         </div>
-        <div id="right-col" class="col-sm-12 col-md-12 col-lg position-relative align-self-center" style="min-width: 374px">
+        <div id="right-col" class="col-sm-12 col-md-12 col-lg position-relative align-self-center">
           <div class="card bg-transparent" id="right-card">
             <div class="top-panel card-header" id="right-panel-header" style="visibility: hidden">
               <div id="user-dropdown" class="dropdown btn-toolbar my-auto me-auto position-relative" style="max-width: 42%">
@@ -792,7 +792,7 @@
                               </div>
                             </div>
                             <div class="col">
-                          <div class="form-check form-switch">
+                              <div class="form-check form-switch">
                                 <input class="form-check-input" type="checkbox" role="switch" id="multiboard-toggle" checked>
                                 <label class="form-check-label" for="multiboard-toggle"><span id="multiboard-toggle-icon" class="fa fa-window-restore dropdown-icon" aria-hidden="false"></span>Multi-board Mode</label>
                               </div>

--- a/play.html
+++ b/play.html
@@ -1059,6 +1059,9 @@
       </div>
     </div>
   </div>
+  <button id="chat-restore-btn" class="btn btn-primary" aria-label="Show Chat">
+    <span class="fa fa-comment"></span>
+  </button>
   <div class="offcanvas offcanvas-end" tabindex="-1" id="chat-offcanvas" aria-labelledby="chat-offcanvas-label">
     <div class="offcanvas-header">
       <h5 class="offcanvas-title" id="chat-offcanvas-label">Chat</h5>

--- a/play.html
+++ b/play.html
@@ -801,20 +801,6 @@
                           <div class="form-group row">
                             <div class="col">
                               <div class="form-check form-switch">
-                                <input class="form-check-input" type="checkbox" role="switch" id="chat-hide-column-toggle" checked>
-                                <label class="form-check-label" for="chat-hide-column-toggle"><span class="fa-solid fa-arrows-left-right-to-line dropdown-icon" aria-hidden="false"></span>Hide Chat Column</label>
-                              </div>
-                            </div>
-                            <div class="col">
-                              <div class="form-check form-switch">
-                                <input class="form-check-input" type="checkbox" role="switch" id="chat-overlay-toggle">
-                                <label class="form-check-label" for="chat-overlay-toggle"><span class="fa-solid fa-window-maximize dropdown-icon" aria-hidden="false"></span>Chat Overlay</label>
-                              </div>
-                            </div>
-                          </div>
-                          <div class="form-group row">
-                            <div class="col">
-                              <div class="form-check form-switch">
                                 <input class="form-check-input" type="checkbox" role="switch" id="multiple-premoves-toggle" checked>
                                 <label class="form-check-label" for="multiple-premoves-toggle"><span id="multiple-premoves-toggle-icon" class="fa-solid fa-arrows-turn-to-dots dropdown-icon" aria-hidden="false"></span>Multiple Premoves</label>
                               </div>

--- a/play.html
+++ b/play.html
@@ -1045,9 +1045,6 @@
       </div>
     </div>
   </div>
-  <button id="chat-restore-btn" class="btn btn-primary" aria-label="Show Chat">
-    <span class="fa fa-comment"></span>
-  </button>
   <div class="offcanvas offcanvas-end" tabindex="-1" id="chat-offcanvas" aria-labelledby="chat-offcanvas-label">
     <div class="offcanvas-header">
       <h5 class="offcanvas-title" id="chat-offcanvas-label">Chat</h5>

--- a/play.html
+++ b/play.html
@@ -1045,14 +1045,6 @@
       </div>
     </div>
   </div>
-  <div class="offcanvas offcanvas-end" tabindex="-1" id="chat-offcanvas" aria-labelledby="chat-offcanvas-label">
-    <div class="offcanvas-header">
-      <h5 class="offcanvas-title" id="chat-offcanvas-label">Chat</h5>
-      <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
-    </div>
-    <div class="offcanvas-body p-0">
-    </div>
-  </div>
   <script src="https://code.jquery.com/jquery-3.7.0.slim.min.js" integrity="sha256-tG5mcZUtJsZvyKAxYLVXrmjKBVLd6VpVccqz/r4ypFE=" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js" integrity="sha384-oBqDVmMz9ATKxIep9tiCxS/Z9fNfEXiDAYTujMAeBAsjFuCZSmKbSSUnQlmh/jp3" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.min.js" integrity="sha384-cuYeSxntonz0PPNlHhBs68uyIAVpIIOZZ5JqeqvYYIcEL727kskC66kF92t6Xl2V" crossorigin="anonymous"></script>

--- a/play.html
+++ b/play.html
@@ -792,9 +792,23 @@
                               </div>
                             </div>
                             <div class="col">
-                              <div class="form-check form-switch">
+                          <div class="form-check form-switch">
                                 <input class="form-check-input" type="checkbox" role="switch" id="multiboard-toggle" checked>
                                 <label class="form-check-label" for="multiboard-toggle"><span id="multiboard-toggle-icon" class="fa fa-window-restore dropdown-icon" aria-hidden="false"></span>Multi-board Mode</label>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <div class="col">
+                              <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" role="switch" id="chat-hide-column-toggle" checked>
+                                <label class="form-check-label" for="chat-hide-column-toggle"><span class="fa-solid fa-arrows-left-right-to-line dropdown-icon" aria-hidden="false"></span>Hide Chat Column</label>
+                              </div>
+                            </div>
+                            <div class="col">
+                              <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" role="switch" id="chat-overlay-toggle">
+                                <label class="form-check-label" for="chat-overlay-toggle"><span class="fa-solid fa-window-maximize dropdown-icon" aria-hidden="false"></span>Chat Overlay</label>
                               </div>
                             </div>
                           </div>
@@ -1043,6 +1057,14 @@
           </div>
         </div>
       </div>
+    </div>
+  </div>
+  <div class="offcanvas offcanvas-end" tabindex="-1" id="chat-offcanvas" aria-labelledby="chat-offcanvas-label">
+    <div class="offcanvas-header">
+      <h5 class="offcanvas-title" id="chat-offcanvas-label">Chat</h5>
+      <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body p-0">
     </div>
   </div>
   <script src="https://code.jquery.com/jquery-3.7.0.slim.min.js" integrity="sha256-tG5mcZUtJsZvyKAxYLVXrmjKBVLd6VpVccqz/r4ypFE=" crossorigin="anonymous"></script>

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -194,7 +194,6 @@ export class Chat {
 
     $('#collapse-chat').on('hidden.bs.collapse', () => {
       if(!isSmallWindow() && $('#secondary-board-area').children().length === 0) {
-        $('#right-col').addClass('chat-collapsed');
         $('body').addClass('chat-hidden');
         $(window).trigger('resize');
       }
@@ -213,7 +212,6 @@ export class Chat {
     $('#collapse-chat').on('show.bs.collapse', () => {
       $('#chat-toggle-btn').addClass('toggle-btn-selected');
       if(!isSmallWindow()) {
-        $('#right-col').removeClass('chat-collapsed');
         $('body').removeClass('chat-hidden');
         $(window).trigger('resize');
       }
@@ -268,7 +266,6 @@ export class Chat {
 
     this.initStartChatMenu();
     this.initEmojis();
-
   }
 
   public connected(user: string): void {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -194,7 +194,7 @@ export class Chat {
 
     $('#collapse-chat').on('hidden.bs.collapse', () => {
       if(!isSmallWindow() && $('#secondary-board-area').children().length === 0) {
-        $('#right-col').addClass('d-none');
+        $('#right-col').addClass('chat-collapsed');
         $('body').addClass('chat-hidden');
         $('#chat-restore-btn').show();
         $(window).trigger('resize');
@@ -214,7 +214,7 @@ export class Chat {
     $('#collapse-chat').on('show.bs.collapse', () => {
       $('#chat-toggle-btn').addClass('toggle-btn-selected');
       if(!isSmallWindow()) {
-        $('#right-col').removeClass('d-none');
+        $('#right-col').removeClass('chat-collapsed');
         $('body').removeClass('chat-hidden');
         $('#chat-restore-btn').hide();
         $(window).trigger('resize');
@@ -305,7 +305,7 @@ export class Chat {
       $('#chat-panel').appendTo('#collapse-chat');
       $('#chat-toggle-btn').removeClass('toggle-btn-selected');
       if(!isSmallWindow() && $('#secondary-board-area').children().length === 0) {
-        $('#right-col').addClass('d-none');
+        $('#right-col').addClass('chat-collapsed');
         $('body').addClass('chat-hidden');
         $('#chat-restore-btn').show();
       }
@@ -314,7 +314,7 @@ export class Chat {
 
     $('#chat-restore-btn').on('click', () => {
       $('#chat-restore-btn').hide();
-      $('#right-col').removeClass('d-none');
+      $('#right-col').removeClass('chat-collapsed');
       $('body').removeClass('chat-hidden');
       if(isSmallWindow()) {
         const offcanvasElem = document.getElementById('chat-offcanvas');

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -193,8 +193,9 @@ export class Chat {
     });
 
     $('#collapse-chat').on('hidden.bs.collapse', () => {
-      if(settings.chatHideColumnToggle && !isSmallWindow() && $('#secondary-board-area').children().length === 0) {
+      if(!isSmallWindow() && $('#secondary-board-area').children().length === 0) {
         $('#right-col').addClass('d-none');
+        $('body').addClass('chat-hidden');
         $('#chat-restore-btn').show();
         $(window).trigger('resize');
       }
@@ -212,8 +213,9 @@ export class Chat {
 
     $('#collapse-chat').on('show.bs.collapse', () => {
       $('#chat-toggle-btn').addClass('toggle-btn-selected');
-      if(settings.chatHideColumnToggle && !isSmallWindow()) {
+      if(!isSmallWindow()) {
         $('#right-col').removeClass('d-none');
+        $('body').removeClass('chat-hidden');
         $('#chat-restore-btn').hide();
         $(window).trigger('resize');
       }
@@ -271,18 +273,17 @@ export class Chat {
 
     // Chat overlay support
     $('#chat-toggle-btn').on('click', (event) => {
-      if(settings.chatOverlayToggle) {
+      if(isSmallWindow()) {
         event.preventDefault();
         const offcanvasElem = document.getElementById('chat-offcanvas');
         if(!offcanvasElem)
           return;
         let offcanvas = bootstrap.Offcanvas.getInstance(offcanvasElem);
-        if(!offcanvas) {
+        if(!offcanvas)
           offcanvas = new bootstrap.Offcanvas(offcanvasElem);
-        }
         if(!offcanvasElem.classList.contains('show')) {
           $('#chat-panel').appendTo('#chat-offcanvas .offcanvas-body');
-          if(settings.chatHideColumnToggle && !isSmallWindow() && $('#secondary-board-area').children().length === 0)
+          if($('#secondary-board-area').children().length === 0)
             $('#right-col').addClass('d-none');
           $('#collapse-chat').collapse('hide');
           offcanvas.show();
@@ -303,17 +304,19 @@ export class Chat {
     $('#chat-offcanvas').on('hidden.bs.offcanvas', () => {
       $('#chat-panel').appendTo('#collapse-chat');
       $('#chat-toggle-btn').removeClass('toggle-btn-selected');
-      if(settings.chatHideColumnToggle && !isSmallWindow() && $('#secondary-board-area').children().length === 0)
+      if(!isSmallWindow() && $('#secondary-board-area').children().length === 0) {
         $('#right-col').addClass('d-none');
-      if(settings.chatHideColumnToggle && !isSmallWindow() && $('#secondary-board-area').children().length === 0)
+        $('body').addClass('chat-hidden');
         $('#chat-restore-btn').show();
+      }
       $(window).trigger('resize');
     });
 
     $('#chat-restore-btn').on('click', () => {
       $('#chat-restore-btn').hide();
       $('#right-col').removeClass('d-none');
-      if(settings.chatOverlayToggle) {
+      $('body').removeClass('chat-hidden');
+      if(isSmallWindow()) {
         const offcanvasElem = document.getElementById('chat-offcanvas');
         if(!offcanvasElem)
           return;

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -193,6 +193,10 @@ export class Chat {
     });
 
     $('#collapse-chat').on('hidden.bs.collapse', () => {
+      if(settings.chatHideColumnToggle && !isSmallWindow() && $('#secondary-board-area').children().length === 0) {
+        $('#right-col').addClass('d-none');
+        $(window).trigger('resize');
+      }
       if(!$('#collapse-chat').hasClass('collapse-init'))
         scrollToBoard();
       $('#collapse-chat').removeClass('collapse-init');
@@ -207,6 +211,10 @@ export class Chat {
 
     $('#collapse-chat').on('show.bs.collapse', () => {
       $('#chat-toggle-btn').addClass('toggle-btn-selected');
+      if(settings.chatHideColumnToggle && !isSmallWindow()) {
+        $('#right-col').removeClass('d-none');
+        $(window).trigger('resize');
+      }
     });
 
     $('#collapse-chat').on('hide.bs.collapse', () => {
@@ -258,6 +266,44 @@ export class Chat {
 
     this.initStartChatMenu();
     this.initEmojis();
+
+    // Chat overlay support
+    $('#chat-toggle-btn').on('click', (event) => {
+      if(settings.chatOverlayToggle) {
+        event.preventDefault();
+        const offcanvasElem = document.getElementById('chat-offcanvas');
+        if(!offcanvasElem)
+          return;
+        let offcanvas = window.bootstrap.Offcanvas.getInstance(offcanvasElem);
+        if(!offcanvas) {
+          offcanvas = new window.bootstrap.Offcanvas(offcanvasElem);
+        }
+        if(!offcanvasElem.classList.contains('show')) {
+          $('#chat-panel').appendTo('#chat-offcanvas .offcanvas-body');
+          if(settings.chatHideColumnToggle && !isSmallWindow() && $('#secondary-board-area').children().length === 0)
+            $('#right-col').addClass('d-none');
+          $('#collapse-chat').collapse('hide');
+          offcanvas.show();
+          $(window).trigger('resize');
+        } else {
+          offcanvas.hide();
+        }
+      }
+    });
+
+    $('#chat-offcanvas').on('shown.bs.offcanvas', () => {
+      $('#chat-toggle-btn').addClass('toggle-btn-selected');
+      $(window).trigger('resize');
+      this.scrollToChat();
+    });
+
+    $('#chat-offcanvas').on('hidden.bs.offcanvas', () => {
+      $('#chat-panel').appendTo('#collapse-chat');
+      $('#chat-toggle-btn').removeClass('toggle-btn-selected');
+      if(settings.chatHideColumnToggle && !isSmallWindow() && $('#secondary-board-area').children().length === 0)
+        $('#right-col').addClass('d-none');
+      $(window).trigger('resize');
+    });
   }
 
   public connected(user: string): void {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -196,7 +196,6 @@ export class Chat {
       if(!isSmallWindow() && $('#secondary-board-area').children().length === 0) {
         $('#right-col').addClass('chat-collapsed');
         $('body').addClass('chat-hidden');
-        $('#chat-restore-btn').show();
         $(window).trigger('resize');
       }
       if(!$('#collapse-chat').hasClass('collapse-init'))
@@ -216,7 +215,6 @@ export class Chat {
       if(!isSmallWindow()) {
         $('#right-col').removeClass('chat-collapsed');
         $('body').removeClass('chat-hidden');
-        $('#chat-restore-btn').hide();
         $(window).trigger('resize');
       }
     });
@@ -287,7 +285,6 @@ export class Chat {
             $('#right-col').addClass('d-none');
           $('#collapse-chat').collapse('hide');
           offcanvas.show();
-          $('#chat-restore-btn').hide();
           $(window).trigger('resize');
         } else {
           offcanvas.hide();
@@ -307,26 +304,6 @@ export class Chat {
       if(!isSmallWindow() && $('#secondary-board-area').children().length === 0) {
         $('#right-col').addClass('chat-collapsed');
         $('body').addClass('chat-hidden');
-        $('#chat-restore-btn').show();
-      }
-      $(window).trigger('resize');
-    });
-
-    $('#chat-restore-btn').on('click', () => {
-      $('#chat-restore-btn').hide();
-      $('#right-col').removeClass('chat-collapsed');
-      $('body').removeClass('chat-hidden');
-      if(isSmallWindow()) {
-        const offcanvasElem = document.getElementById('chat-offcanvas');
-        if(!offcanvasElem)
-          return;
-        let offcanvas = bootstrap.Offcanvas.getInstance(offcanvasElem);
-        if(!offcanvas)
-          offcanvas = new bootstrap.Offcanvas(offcanvasElem);
-        $('#chat-panel').appendTo('#chat-offcanvas .offcanvas-body');
-        offcanvas.show();
-      } else {
-        $('#collapse-chat').collapse('show');
       }
       $(window).trigger('resize');
     });

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -269,44 +269,6 @@ export class Chat {
     this.initStartChatMenu();
     this.initEmojis();
 
-    // Chat overlay support
-    $('#chat-toggle-btn').on('click', (event) => {
-      if(isSmallWindow()) {
-        event.preventDefault();
-        const offcanvasElem = document.getElementById('chat-offcanvas');
-        if(!offcanvasElem)
-          return;
-        let offcanvas = bootstrap.Offcanvas.getInstance(offcanvasElem);
-        if(!offcanvas)
-          offcanvas = new bootstrap.Offcanvas(offcanvasElem);
-        if(!offcanvasElem.classList.contains('show')) {
-          $('#chat-panel').appendTo('#chat-offcanvas .offcanvas-body');
-          if($('#secondary-board-area').children().length === 0)
-            $('#right-col').addClass('d-none');
-          $('#collapse-chat').collapse('hide');
-          offcanvas.show();
-          $(window).trigger('resize');
-        } else {
-          offcanvas.hide();
-        }
-      }
-    });
-
-    $('#chat-offcanvas').on('shown.bs.offcanvas', () => {
-      $('#chat-toggle-btn').addClass('toggle-btn-selected');
-      $(window).trigger('resize');
-      this.scrollToChat();
-    });
-
-    $('#chat-offcanvas').on('hidden.bs.offcanvas', () => {
-      $('#chat-panel').appendTo('#collapse-chat');
-      $('#chat-toggle-btn').removeClass('toggle-btn-selected');
-      if(!isSmallWindow() && $('#secondary-board-area').children().length === 0) {
-        $('#right-col').addClass('chat-collapsed');
-        $('body').addClass('chat-hidden');
-      }
-      $(window).trigger('resize');
-    });
   }
 
   public connected(user: string): void {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -195,6 +195,7 @@ export class Chat {
     $('#collapse-chat').on('hidden.bs.collapse', () => {
       if(settings.chatHideColumnToggle && !isSmallWindow() && $('#secondary-board-area').children().length === 0) {
         $('#right-col').addClass('d-none');
+        $('#chat-restore-btn').show();
         $(window).trigger('resize');
       }
       if(!$('#collapse-chat').hasClass('collapse-init'))
@@ -213,6 +214,7 @@ export class Chat {
       $('#chat-toggle-btn').addClass('toggle-btn-selected');
       if(settings.chatHideColumnToggle && !isSmallWindow()) {
         $('#right-col').removeClass('d-none');
+        $('#chat-restore-btn').hide();
         $(window).trigger('resize');
       }
     });
@@ -274,9 +276,9 @@ export class Chat {
         const offcanvasElem = document.getElementById('chat-offcanvas');
         if(!offcanvasElem)
           return;
-        let offcanvas = window.bootstrap.Offcanvas.getInstance(offcanvasElem);
+        let offcanvas = bootstrap.Offcanvas.getInstance(offcanvasElem);
         if(!offcanvas) {
-          offcanvas = new window.bootstrap.Offcanvas(offcanvasElem);
+          offcanvas = new bootstrap.Offcanvas(offcanvasElem);
         }
         if(!offcanvasElem.classList.contains('show')) {
           $('#chat-panel').appendTo('#chat-offcanvas .offcanvas-body');
@@ -284,6 +286,7 @@ export class Chat {
             $('#right-col').addClass('d-none');
           $('#collapse-chat').collapse('hide');
           offcanvas.show();
+          $('#chat-restore-btn').hide();
           $(window).trigger('resize');
         } else {
           offcanvas.hide();
@@ -302,6 +305,26 @@ export class Chat {
       $('#chat-toggle-btn').removeClass('toggle-btn-selected');
       if(settings.chatHideColumnToggle && !isSmallWindow() && $('#secondary-board-area').children().length === 0)
         $('#right-col').addClass('d-none');
+      if(settings.chatHideColumnToggle && !isSmallWindow() && $('#secondary-board-area').children().length === 0)
+        $('#chat-restore-btn').show();
+      $(window).trigger('resize');
+    });
+
+    $('#chat-restore-btn').on('click', () => {
+      $('#chat-restore-btn').hide();
+      $('#right-col').removeClass('d-none');
+      if(settings.chatOverlayToggle) {
+        const offcanvasElem = document.getElementById('chat-offcanvas');
+        if(!offcanvasElem)
+          return;
+        let offcanvas = bootstrap.Offcanvas.getInstance(offcanvasElem);
+        if(!offcanvas)
+          offcanvas = new bootstrap.Offcanvas(offcanvasElem);
+        $('#chat-panel').appendTo('#chat-offcanvas .offcanvas-body');
+        offcanvas.show();
+      } else {
+        $('#collapse-chat').collapse('show');
+      }
       $(window).trigger('resize');
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,8 @@ async function onDeviceReady() {
     $('#collapse-chat').collapse('hide');
     $('#collapse-menus').collapse('hide');
     setViewModeList();
+    if(settings.chatHideColumnToggle && $('#secondary-board-area').children().length === 0)
+      $('#right-col').addClass('d-none');
   }
   else {
     Utils.createTooltips();
@@ -125,7 +127,14 @@ async function onDeviceReady() {
     $('#pills-play-tab').tab('show');
     $('#collapse-menus').removeClass('collapse-init');
     $('#collapse-chat').removeClass('collapse-init');
-    $('#chat-toggle-btn').toggleClass('toggle-btn-selected');
+    if(settings.chatOverlayToggle) {
+      $('#collapse-chat').collapse('hide');
+      if(settings.chatHideColumnToggle && $('#secondary-board-area').children().length === 0)
+        $('#right-col').addClass('d-none');
+    }
+    else
+      $('#chat-toggle-btn').toggleClass('toggle-btn-selected');
+    $('#right-col').removeClass('d-none');
   }
 
   $('input, [data-select-on-focus]').each(function() {
@@ -346,9 +355,10 @@ function setPanelSizes() {
 
     // Set board width a bit smaller in order to leave room for a scrollbar on <body>. This is because
     // we don't want to resize all the panels whenever a dropdown or something similar overflows the body.
+    const rightColWidth = $('#right-col').is(':visible') ? parseFloat($('#right-col').css('min-width')) : 0;
     const cardMaxWidth = Utils.isMediumWindow() // display 2 columns on md (medium) display
       ? viewportWidth - $('#left-col').outerWidth() - scrollBarReservedArea
-      : viewportWidth - $('#left-col').outerWidth() - parseFloat($('#right-col').css('min-width')) - scrollBarReservedArea;
+      : viewportWidth - $('#left-col').outerWidth() - rightColWidth - scrollBarReservedArea;
 
     const cardMaxHeight = $(window).height() - Utils.getRemainingHeight(maximizedGameCard);
     setGameCardSize(maximizedGame, cardMaxWidth, cardMaxHeight);
@@ -449,6 +459,8 @@ function setGameCardSize(game: Game, cardMaxWidth?: number, cardMaxHeight?: numb
 }
 
 function setRightColumnSizes() {
+  if(!$('#right-col').is(':visible'))
+    return;
   const boardHeight = $('#main-board-area .board').innerHeight();
   // Set chat panel height to 0 before resizing everything so as to remove scrollbar on window caused by chat overflowing
   if(Utils.isLargeWindow())
@@ -3268,6 +3280,9 @@ function makeSecondaryBoard(game: Game) {
   game.element.find('.title-bar').css('display', 'block');
   game.element.appendTo('#secondary-board-area');
   game.board.set({ coordinates: false });
+  if(settings.chatHideColumnToggle && !Utils.isSmallWindow())
+    $('#right-col').removeClass('d-none');
+  $(window).trigger('resize');
 }
 
 export function maximizeGame(game: Game) {
@@ -3345,6 +3360,10 @@ function removeGame(game: Game) {
   if(!$('#secondary-board-area').children().length) {
     $('#secondary-board-area').hide();
     $('#collapse-chat-arrow').hide();
+    if(settings.chatHideColumnToggle && !$('#collapse-chat').hasClass('show') && !Utils.isSmallWindow()) {
+      $('#right-col').addClass('d-none');
+      $(window).trigger('resize');
+    }
   }
   setRightColumnSizes();
 
@@ -6326,6 +6345,12 @@ function initSettings() {
   settings.smartmoveToggle = (storage.get('smartmove') === 'true');
   $('#smartmove-toggle').prop('checked', settings.smartmoveToggle);
 
+  settings.chatHideColumnToggle = (storage.get('chat-hide-column') !== 'false');
+  $('#chat-hide-column-toggle').prop('checked', settings.chatHideColumnToggle);
+
+  settings.chatOverlayToggle = (storage.get('chat-overlay') === 'true');
+  $('#chat-overlay-toggle').prop('checked', settings.chatOverlayToggle);
+
   settings.rememberMeToggle = (storage.get('rememberme') === 'true');
   $('#remember-me').prop('checked', settings.rememberMeToggle);
 
@@ -6413,6 +6438,16 @@ $('#multiple-premoves-toggle').on('click', () => {
 $('#smartmove-toggle').on('click', () => {
   settings.smartmoveToggle = !settings.smartmoveToggle;
   storage.set('smartmove', String(settings.smartmoveToggle));
+});
+
+$('#chat-hide-column-toggle').on('click', () => {
+  settings.chatHideColumnToggle = !settings.chatHideColumnToggle;
+  storage.set('chat-hide-column', String(settings.chatHideColumnToggle));
+});
+
+$('#chat-overlay-toggle').on('click', () => {
+  settings.chatOverlayToggle = !settings.chatOverlayToggle;
+  storage.set('chat-overlay', String(settings.chatOverlayToggle));
 });
 
 /** *****************************

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ async function onDeviceReady() {
     $('#collapse-chat').collapse('hide');
     $('#collapse-menus').collapse('hide');
     setViewModeList();
-    if(settings.chatHideColumnToggle && $('#secondary-board-area').children().length === 0) {
+    if($('#secondary-board-area').children().length === 0) {
       $('#right-col').addClass('d-none');
       $('#chat-restore-btn').show();
     }
@@ -129,18 +129,10 @@ async function onDeviceReady() {
     $('#pills-play-tab').tab('show');
     $('#collapse-menus').removeClass('collapse-init');
     $('#collapse-chat').removeClass('collapse-init');
-    if(settings.chatOverlayToggle) {
-      $('#collapse-chat').collapse('hide');
-      if(settings.chatHideColumnToggle && $('#secondary-board-area').children().length === 0) {
-        $('#right-col').addClass('d-none');
-        $('#chat-restore-btn').show();
-      }
-    }
-    else {
-      $('#chat-toggle-btn').toggleClass('toggle-btn-selected');
-      $('#chat-restore-btn').hide();
-    }
+    $('#chat-toggle-btn').toggleClass('toggle-btn-selected');
+    $('#chat-restore-btn').hide();
     $('#right-col').removeClass('d-none');
+    $('body').removeClass('chat-hidden');
   }
 
   $('input, [data-select-on-focus]').each(function() {
@@ -3286,8 +3278,9 @@ function makeSecondaryBoard(game: Game) {
   game.element.find('.title-bar').css('display', 'block');
   game.element.appendTo('#secondary-board-area');
   game.board.set({ coordinates: false });
-  if(settings.chatHideColumnToggle && !Utils.isSmallWindow()) {
+  if(!Utils.isSmallWindow()) {
     $('#right-col').removeClass('d-none');
+    $('body').removeClass('chat-hidden');
     $('#chat-restore-btn').hide();
   }
   $(window).trigger('resize');
@@ -3368,8 +3361,9 @@ function removeGame(game: Game) {
   if(!$('#secondary-board-area').children().length) {
     $('#secondary-board-area').hide();
     $('#collapse-chat-arrow').hide();
-    if(settings.chatHideColumnToggle && !$('#collapse-chat').hasClass('show') && !Utils.isSmallWindow()) {
+    if(!$('#collapse-chat').hasClass('show') && !Utils.isSmallWindow()) {
       $('#right-col').addClass('d-none');
+      $('body').addClass('chat-hidden');
       $('#chat-restore-btn').show();
       $(window).trigger('resize');
     }
@@ -6354,11 +6348,6 @@ function initSettings() {
   settings.smartmoveToggle = (storage.get('smartmove') === 'true');
   $('#smartmove-toggle').prop('checked', settings.smartmoveToggle);
 
-  settings.chatHideColumnToggle = (storage.get('chat-hide-column') !== 'false');
-  $('#chat-hide-column-toggle').prop('checked', settings.chatHideColumnToggle);
-
-  settings.chatOverlayToggle = (storage.get('chat-overlay') === 'true');
-  $('#chat-overlay-toggle').prop('checked', settings.chatOverlayToggle);
 
   settings.rememberMeToggle = (storage.get('rememberme') === 'true');
   $('#remember-me').prop('checked', settings.rememberMeToggle);
@@ -6449,15 +6438,6 @@ $('#smartmove-toggle').on('click', () => {
   storage.set('smartmove', String(settings.smartmoveToggle));
 });
 
-$('#chat-hide-column-toggle').on('click', () => {
-  settings.chatHideColumnToggle = !settings.chatHideColumnToggle;
-  storage.set('chat-hide-column', String(settings.chatHideColumnToggle));
-});
-
-$('#chat-overlay-toggle').on('click', () => {
-  settings.chatOverlayToggle = !settings.chatOverlayToggle;
-  storage.set('chat-overlay', String(settings.chatOverlayToggle));
-});
 
 /** *****************************
  * CONSOLE/CHAT INPUT FUNCTIONS *

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,8 +118,10 @@ async function onDeviceReady() {
     $('#collapse-chat').collapse('hide');
     $('#collapse-menus').collapse('hide');
     setViewModeList();
-    if(settings.chatHideColumnToggle && $('#secondary-board-area').children().length === 0)
+    if(settings.chatHideColumnToggle && $('#secondary-board-area').children().length === 0) {
       $('#right-col').addClass('d-none');
+      $('#chat-restore-btn').show();
+    }
   }
   else {
     Utils.createTooltips();
@@ -129,11 +131,15 @@ async function onDeviceReady() {
     $('#collapse-chat').removeClass('collapse-init');
     if(settings.chatOverlayToggle) {
       $('#collapse-chat').collapse('hide');
-      if(settings.chatHideColumnToggle && $('#secondary-board-area').children().length === 0)
+      if(settings.chatHideColumnToggle && $('#secondary-board-area').children().length === 0) {
         $('#right-col').addClass('d-none');
+        $('#chat-restore-btn').show();
+      }
     }
-    else
+    else {
       $('#chat-toggle-btn').toggleClass('toggle-btn-selected');
+      $('#chat-restore-btn').hide();
+    }
     $('#right-col').removeClass('d-none');
   }
 
@@ -3280,8 +3286,10 @@ function makeSecondaryBoard(game: Game) {
   game.element.find('.title-bar').css('display', 'block');
   game.element.appendTo('#secondary-board-area');
   game.board.set({ coordinates: false });
-  if(settings.chatHideColumnToggle && !Utils.isSmallWindow())
+  if(settings.chatHideColumnToggle && !Utils.isSmallWindow()) {
     $('#right-col').removeClass('d-none');
+    $('#chat-restore-btn').hide();
+  }
   $(window).trigger('resize');
 }
 
@@ -3362,6 +3370,7 @@ function removeGame(game: Game) {
     $('#collapse-chat-arrow').hide();
     if(settings.chatHideColumnToggle && !$('#collapse-chat').hasClass('show') && !Utils.isSmallWindow()) {
       $('#right-col').addClass('d-none');
+      $('#chat-restore-btn').show();
       $(window).trigger('resize');
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,8 +118,6 @@ async function onDeviceReady() {
     $('#collapse-chat').collapse('hide');
     $('#collapse-menus').collapse('hide');
     setViewModeList();
-    if($('#secondary-board-area').children().length === 0)
-      $('#right-col').addClass('chat-collapsed');
   }
   else {
     Utils.createTooltips();

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,6 @@ async function onDeviceReady() {
     $('#collapse-menus').removeClass('collapse-init');
     $('#collapse-chat').removeClass('collapse-init');
     $('#chat-toggle-btn').toggleClass('toggle-btn-selected');
-    $('#right-col').removeClass('chat-collapsed');
     $('body').removeClass('chat-hidden');
   }
 
@@ -348,7 +347,7 @@ function setPanelSizes() {
 
     // Set board width a bit smaller in order to leave room for a scrollbar on <body>. This is because
     // we don't want to resize all the panels whenever a dropdown or something similar overflows the body.
-    const rightColWidth = ($('#right-col').is(':visible') && !$('#right-col').hasClass('chat-collapsed'))
+    const rightColWidth = ($('#right-col').is(':visible') && !$('body').hasClass('chat-hidden'))
       ? parseFloat($('#right-col').css('min-width')) : 0;
     const cardMaxWidth = Utils.isMediumWindow() // display 2 columns on md (medium) display
       ? viewportWidth - $('#left-col').outerWidth() - scrollBarReservedArea
@@ -453,7 +452,7 @@ function setGameCardSize(game: Game, cardMaxWidth?: number, cardMaxHeight?: numb
 }
 
 function setRightColumnSizes() {
-  if(!$('#right-col').is(':visible') || $('#right-col').hasClass('chat-collapsed'))
+  if(!$('#right-col').is(':visible') || $('body').hasClass('chat-hidden'))
     return;
   const boardHeight = $('#main-board-area .board').innerHeight();
   // Set chat panel height to 0 before resizing everything so as to remove scrollbar on window caused by chat overflowing
@@ -3275,7 +3274,6 @@ function makeSecondaryBoard(game: Game) {
   game.element.appendTo('#secondary-board-area');
   game.board.set({ coordinates: false });
   if(!Utils.isSmallWindow()) {
-    $('#right-col').removeClass('chat-collapsed');
     $('body').removeClass('chat-hidden');
   }
   $(window).trigger('resize');
@@ -3357,7 +3355,6 @@ function removeGame(game: Game) {
     $('#secondary-board-area').hide();
     $('#collapse-chat-arrow').hide();
     if(!$('#collapse-chat').hasClass('show') && !Utils.isSmallWindow()) {
-      $('#right-col').addClass('chat-collapsed');
       $('body').addClass('chat-hidden');
       $(window).trigger('resize');
     }
@@ -6342,7 +6339,6 @@ function initSettings() {
   settings.smartmoveToggle = (storage.get('smartmove') === 'true');
   $('#smartmove-toggle').prop('checked', settings.smartmoveToggle);
 
-
   settings.rememberMeToggle = (storage.get('rememberme') === 'true');
   $('#remember-me').prop('checked', settings.rememberMeToggle);
 
@@ -6431,7 +6427,6 @@ $('#smartmove-toggle').on('click', () => {
   settings.smartmoveToggle = !settings.smartmoveToggle;
   storage.set('smartmove', String(settings.smartmoveToggle));
 });
-
 
 /** *****************************
  * CONSOLE/CHAT INPUT FUNCTIONS *

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,10 +118,8 @@ async function onDeviceReady() {
     $('#collapse-chat').collapse('hide');
     $('#collapse-menus').collapse('hide');
     setViewModeList();
-    if($('#secondary-board-area').children().length === 0) {
+    if($('#secondary-board-area').children().length === 0)
       $('#right-col').addClass('chat-collapsed');
-      $('#chat-restore-btn').show();
-    }
   }
   else {
     Utils.createTooltips();
@@ -130,7 +128,6 @@ async function onDeviceReady() {
     $('#collapse-menus').removeClass('collapse-init');
     $('#collapse-chat').removeClass('collapse-init');
     $('#chat-toggle-btn').toggleClass('toggle-btn-selected');
-    $('#chat-restore-btn').hide();
     $('#right-col').removeClass('chat-collapsed');
     $('body').removeClass('chat-hidden');
   }
@@ -353,7 +350,8 @@ function setPanelSizes() {
 
     // Set board width a bit smaller in order to leave room for a scrollbar on <body>. This is because
     // we don't want to resize all the panels whenever a dropdown or something similar overflows the body.
-    const rightColWidth = $('#right-col').is(':visible') ? parseFloat($('#right-col').css('min-width')) : 0;
+    const rightColWidth = ($('#right-col').is(':visible') && !$('#right-col').hasClass('chat-collapsed'))
+      ? parseFloat($('#right-col').css('min-width')) : 0;
     const cardMaxWidth = Utils.isMediumWindow() // display 2 columns on md (medium) display
       ? viewportWidth - $('#left-col').outerWidth() - scrollBarReservedArea
       : viewportWidth - $('#left-col').outerWidth() - rightColWidth - scrollBarReservedArea;
@@ -457,7 +455,7 @@ function setGameCardSize(game: Game, cardMaxWidth?: number, cardMaxHeight?: numb
 }
 
 function setRightColumnSizes() {
-  if(!$('#right-col').is(':visible'))
+  if(!$('#right-col').is(':visible') || $('#right-col').hasClass('chat-collapsed'))
     return;
   const boardHeight = $('#main-board-area .board').innerHeight();
   // Set chat panel height to 0 before resizing everything so as to remove scrollbar on window caused by chat overflowing
@@ -3281,7 +3279,6 @@ function makeSecondaryBoard(game: Game) {
   if(!Utils.isSmallWindow()) {
     $('#right-col').removeClass('chat-collapsed');
     $('body').removeClass('chat-hidden');
-    $('#chat-restore-btn').hide();
   }
   $(window).trigger('resize');
 }
@@ -3364,7 +3361,6 @@ function removeGame(game: Game) {
     if(!$('#collapse-chat').hasClass('show') && !Utils.isSmallWindow()) {
       $('#right-col').addClass('chat-collapsed');
       $('body').addClass('chat-hidden');
-      $('#chat-restore-btn').show();
       $(window).trigger('resize');
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ async function onDeviceReady() {
     $('#collapse-menus').collapse('hide');
     setViewModeList();
     if($('#secondary-board-area').children().length === 0) {
-      $('#right-col').addClass('d-none');
+      $('#right-col').addClass('chat-collapsed');
       $('#chat-restore-btn').show();
     }
   }
@@ -131,7 +131,7 @@ async function onDeviceReady() {
     $('#collapse-chat').removeClass('collapse-init');
     $('#chat-toggle-btn').toggleClass('toggle-btn-selected');
     $('#chat-restore-btn').hide();
-    $('#right-col').removeClass('d-none');
+    $('#right-col').removeClass('chat-collapsed');
     $('body').removeClass('chat-hidden');
   }
 
@@ -3279,7 +3279,7 @@ function makeSecondaryBoard(game: Game) {
   game.element.appendTo('#secondary-board-area');
   game.board.set({ coordinates: false });
   if(!Utils.isSmallWindow()) {
-    $('#right-col').removeClass('d-none');
+    $('#right-col').removeClass('chat-collapsed');
     $('body').removeClass('chat-hidden');
     $('#chat-restore-btn').hide();
   }
@@ -3362,7 +3362,7 @@ function removeGame(game: Game) {
     $('#secondary-board-area').hide();
     $('#collapse-chat-arrow').hide();
     if(!$('#collapse-chat').hasClass('show') && !Utils.isSmallWindow()) {
-      $('#right-col').addClass('d-none');
+      $('#right-col').addClass('chat-collapsed');
       $('body').addClass('chat-hidden');
       $('#chat-restore-btn').show();
       $(window).trigger('resize');

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -30,6 +30,10 @@ export const settings = {
   timestampToggle: true,
   // toggle for creating separate chat tabs instead of displaying messages in the console
   chattabsToggle: true,
+  // toggle for hiding chat column when collapsed
+  chatHideColumnToggle: true,
+  // toggle for using an overlay for chat instead of collapsing
+  chatOverlayToggle: false,
 
   /** History settings */
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -30,10 +30,6 @@ export const settings = {
   timestampToggle: true,
   // toggle for creating separate chat tabs instead of displaying messages in the console
   chattabsToggle: true,
-  // toggle for hiding chat column when collapsed
-  chatHideColumnToggle: true,
-  // toggle for using an overlay for chat instead of collapsing
-  chatOverlayToggle: false,
 
   /** History settings */
 


### PR DESCRIPTION
## Summary
- Put chat panel on top when collapsed on wider screens

![image](https://github.com/user-attachments/assets/1c857e97-d507-4abd-9bc8-e49f41c67030)


## Testing
- `yarn install`
- `yarn lint` *(fails: many existing style errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a32ae896c832bbdb04dffaad0668b