### PR TITLE
Fix panels jumping glitch when expanding chat

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -449,7 +449,7 @@ function setGameCardSize(game: Game, cardMaxWidth?: number, cardMaxHeight?: numb
 }
 
 function setRightColumnSizes() {
-  if(!$('#right-col').is(':visible') || $('body').hasClass('chat-hidden'))
+  if($('body').hasClass('chat-hidden') || !$('#collapse-chat').hasClass('show'))
     return;
   const boardHeight = $('#main-board-area .board').innerHeight();
   // Set chat panel height to 0 before resizing everything so as to remove scrollbar on window caused by chat overflowing


### PR DESCRIPTION
Tested out the collapsing chat column thing. 
It works good, I just fixed one minor glitch with the left columns jumping when it expands (due to the right column trying to resize before it's fully expanded).

While testing it, I started wondering whether this feature is an improvement though. In most cases, it just makes the board smaller, due to the login panel taking up extra height above the board. Not a huge fan of the stretched left column either. Maybe I'd have just left it the way it was, but made it so the collapsed columns don't center their content, but align to the top instead. 