### PR TITLE
Fix bugs change movetime

### DIFF
--- a/assets/css/application.css
+++ b/assets/css/application.css
@@ -539,6 +539,8 @@ body {
   vertical-align: top;
   padding-top: 1px;
   padding-bottom: 1px;
+  padding-left: 15px;
+  padding-right: 15px;
   text-decoration: none;
 }
 #move-table .selectable:hover .move {
@@ -563,8 +565,6 @@ body {
   border-width: 0 3px;
 }
 #move-table .selected {
-  border-left: 15px solid transparent;
-  border-right: 15px solid transparent;
   font-weight: bold;
 }
 
@@ -689,13 +689,13 @@ body {
 }
 
 .movetime {
-  display: none;
+  display: inline-block;
+  text-align: left;
+  margin-left: 1rem;
   font-size: 0.75em;
-  color: var(--bs-secondary-color, #6c757d);
+  min-width: 10ch;
 }
-#left-panel:not(.list-view-showing) .movetime {
-  display: inline;
-}
+
 #textsize-range {
   width: 60px;
   height: auto;

--- a/assets/css/themes/base-theme-dark.css
+++ b/assets/css/themes/base-theme-dark.css
@@ -249,6 +249,10 @@ a {
   color: currentColor;
 }
 
+.movetime {
+  color: #999999;
+}
+
 .movelist .selected {
   background-color: rgba(255, 255, 255, 0.3);
   color: #FFFFFF;

--- a/assets/css/themes/base-theme-light.css
+++ b/assets/css/themes/base-theme-light.css
@@ -159,6 +159,10 @@ cg-board {
   color: color-mix(in srgb, currentColor 70%, white 30%); /* fancy new method for lightening/darkening colors */
 }
 
+.movetime {
+  color: var(--bs-secondary-color, #6c757d);
+}
+
 .movelist .selected {
   background-color: rgba(0, 0, 0, 0.2);
   color: #000000;

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -159,11 +159,11 @@ export class Chat {
     // initialize tabs
     this.tabData = {};
 
-    $(document).on('show.bs.tab', '#tabs button[data-bs-toggle="tab"]', async (e) => {
+    $(document).on('show.bs.tab', '#tabs button[data-bs-toggle="tab"]', (e) => {
       this.createInChannelTimer(this.getTabName($(e.target)));
     });
 
-    $(document).on('shown.bs.tab', '#tabs button[data-bs-toggle="tab"]', async (e) => {
+    $(document).on('shown.bs.tab', '#tabs button[data-bs-toggle="tab"]', (e) => {
       const tab = $(e.target);
       this.updateViewedState(tab);
       this.updateVirtualScroller(tab);
@@ -416,7 +416,7 @@ export class Chat {
     removeWithTooltips($(`#content-${name}`));
   }
 
-  public async createTab(name: string, showTab = false) {
+  public createTab(name: string, showTab = false) {
     let from: string;
     if(!settings.chattabsToggle)
       from = 'console';
@@ -715,13 +715,13 @@ export class Chat {
     });
   }
 
-  public async newMessage(from: string, data: any, html = false) {
+  public newMessage(from: string, data: any, html = false) {
     const tabName = settings.chattabsToggle ? from : 'console';
 
     if(!/^[\w- ]+$/.test(from))
       return;
 
-    const tabElement = await this.createTab(tabName);
+    const tabElement = this.createTab(tabName);
     let who = '';
     if (data.user !== undefined) {
       let textclass = '';
@@ -768,7 +768,7 @@ export class Chat {
       if(!settings.chattabsToggle)
         return;
 
-      const dateTime = await convertToLocalDateTime(data.datetime);
+      const dateTime = convertToLocalDateTime(data.datetime);
       const now = new Date();
 
       const dateOptions: any = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3104,6 +3104,7 @@ function createGame(): Game {
     game.board = createBoard(game.element.find('.board'));
     leaveSetupBoard(game);
     makeSecondaryBoard(game);
+    $(window).trigger('resize');
     game.element.find($('[title="Close"]')).css('visibility', 'visible');
     $('#secondary-board-area').css('display', 'flex');
     $('#collapse-chat-arrow').show();
@@ -3273,7 +3274,6 @@ function makeSecondaryBoard(game: Game) {
   if(!Utils.isSmallWindow()) {
     $('body').removeClass('chat-hidden');
   }
-  $(window).trigger('resize');
 }
 
 export function maximizeGame(game: Game) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2186,34 +2186,41 @@ function setClocks(game: Game) {
 
 // Start clock after a move, switch from white to black's clock etc
 function hitClock(game: Game, bSetClocks = false) {
-  if(game.isPlaying() || game.role === Role.OBSERVING) {
-    const ply = game.history.last().ply;
-    const turnColor = game.history.last().turnColor;
+  if(!game.isPlaying && game.role !== Role.OBSERVING)
+    return;
 
-    // If a move was received from the server, set the clocks to the updated times
-    // Note: When in examine mode this is handled by setClocks() instead
-    if(bSetClocks) { // Get remaining time from server message
-      if(game.category === 'untimed') {
-        game.clock.setWhiteClock(null);
-        game.clock.setBlackClock(null);
-      }
-      else {
-        game.clock.setWhiteClock();
-        game.clock.setBlackClock();
-      }
-    }
-    else if(game.inc !== 0) { // Manually add time increment
-      if(turnColor === 'w' && ply >= 5)
-        game.clock.setBlackClock(game.clock.getBlackTime() + game.inc * 1000);
-      else if(turnColor === 'b' && ply >= 4)
-        game.clock.setWhiteClock(game.clock.getWhiteTime() + game.inc * 1000);
-    }
-
-    if((ply >= 3 || game.category === 'bughouse') && turnColor === 'w')
-      game.clock.startWhiteClock();
-    else if((ply >= 4 || game.category === 'bughouse') && turnColor === 'b')
-      game.clock.startBlackClock();
+  let ply = game.history.last().ply;
+  let turnColor = game.history.last().turnColor;
+  if(!bSetClocks) { 
+    // Note if hitClock() is called from movePiece() then we haven't yet added the move 
+    // to the history yet.
+    ply++;
+    turnColor = turnColor === 'w' ? 'b' : 'w';
   }
+
+  // If a move was received from the server, set the clocks to the updated times
+  // Note: When in examine mode this is handled by setClocks() instead
+  if(bSetClocks) { // Get remaining time from server message
+    if(game.category === 'untimed') {
+      game.clock.setWhiteClock(null);
+      game.clock.setBlackClock(null);
+    }
+    else {
+      game.clock.setWhiteClock();
+      game.clock.setBlackClock();
+    }
+  }
+  else if(game.inc !== 0) { // Manually add time increment
+    if(turnColor === 'w' && ply >= 5) 
+      game.clock.setBlackClock(game.clock.getBlackTime() + game.inc * 1000);
+    else if(turnColor === 'b' && ply >= 4) 
+      game.clock.setWhiteClock(game.clock.getWhiteTime() + game.inc * 1000);
+  }
+
+  if((ply >= 3 || game.category === 'bughouse') && turnColor === 'w')
+    game.clock.startWhiteClock();
+  else if((ply >= 4 || game.category === 'bughouse') && turnColor === 'b')
+    game.clock.startBlackClock();
 }
 
 /** GAME BOARD FUNCTIONS **/

--- a/src/index.ts
+++ b/src/index.ts
@@ -665,11 +665,11 @@ function messageHandler(data: any) {
         chat.newMessage(data.messages[0].user, data.messages[0]);
       else if(data.type === 'unread' && awaiting.resolve('unread-messages')) {
         data.messages.forEach(msg => chat.newMessage(msg.user, msg));
-        chat.showTab(data.messages[0].user);
         if($('#collapse-chat').hasClass('show'))
           chat.scrollToChat();
         else
           $('#collapse-chat').collapse('show');
+        chat.showTab(data.messages[0].user);
         return;
       }
       chat.newMessage('console', { message: data.raw });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,14 +107,15 @@ export function setDefaultTimezone(timezone: string) {
       : timezoneOffsets[timezone] || 0;
 }
 
-export async function convertToLocalDateTime(dateTime: any) {
+export function convertToLocalDateTime(dateTime: any) {
   const offset = timezoneOffsets[dateTime.timezone] !== undefined
       ? timezoneOffsets[dateTime.timezone] 
       : defaultTimezone; 
 
   const timezone = timezoneOffsetToHHMM(offset);
   const month = Number.isInteger(Number(dateTime.month)) ? dateTime.month : monthShortNameToNumber(dateTime.month)?.toString().padStart(2, "0");
-  const dateTimeStr = `${dateTime.year}-${month}-${dateTime.day}T${dateTime.hour}:${dateTime.minute}:${dateTime.second || '00'}${timezone}`;
+  const day = dateTime.day.padStart(2, '0');
+  const dateTimeStr = `${dateTime.year}-${month}-${day}T${dateTime.hour}:${dateTime.minute}:${dateTime.second || '00'}${timezone}`;
   return new Date(dateTimeStr);
 }
 


### PR DESCRIPTION
- Found another bug in the 'minimize chat' code. It was bugging out when you maximize (double click) a small board over the right.
- Fixed bugs with messages in chat tabs
- I tried out the move times in the move list feature and made some changes (hopefully improvements). First I think that total elapsed game time is not the most useful metric. So I changed it to time taken for each individual move, displayed in minutes and seconds (to 1 decimal place). This seems more useful, what do you think? Secondly I fixed a bunch of bugs in the code. In particular:
   * Time increments were a bit buggy, it was adding increments to moves even when the clocks hadn't started yet (first 4 ply)
   * It also now displays moves when examining a History game.
   * Other misc bug fixes.
   
  Try it out, let me know what you think.  