### PR TITLE
Fix regex's that were failing for users with rating < 1000

### DIFF
--- a/src/js/parser.ts
+++ b/src/js/parser.ts
@@ -244,6 +244,10 @@ export class Parser {
 
     let match = null;
 
+    // Ignore text in help files
+    if(/^\[?Last Modified/m.test(msg))
+      return { message: msg };
+
     // game move
     match = msg.match(/(?:^|\n)<12>\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([rnbqkpRNBQKP\-]{8})\s([BW\-])\s(\-?[0-7])\s([01])\s([01])\s([01])\s([01])\s([0-9]+)\s([0-9]+)\s(\S+)\s(\S+)\s(\-?[0-3])\s([0-9]+)\s([0-9]+)\s([0-9]+)\s([0-9]+)\s(\-?[0-9]+)\s(\-?[0-9]+)\s([0-9]+)\s(\S+)\s\(([0-9]+)\:([0-9]+)\.([0-9]+)\)\s(\S+)\s([01])\s([0-9]+)\s([0-9]+)\s*/);
     if(match != null && match.length >= 34) {
@@ -460,7 +464,7 @@ export class Parser {
       for(let line of lines) {
         line = line.trim();
         // parse pendinfo
-        match = line.match(/^<(pt|pf)> (\d+) w=(\S+) t=(\S+) p=((\S+)(?: \((\S+)\)(?: \[(black|white)\])? (\S+) \((\S+)\) (rated|unrated) (\S+)(?: (\d+) (\d+))?(?: Loaded from (\S+))?( \(adjourned\))?)?)/);
+        match = line.match(/^<(pt|pf)> (\d+) w=(\S+) t=(\S+) p=((\S+)(?: \(\s*(\S+)\)(?: \[(black|white)\])? (\S+) \(\s*(\S+)\) (rated|unrated) (\S+)(?: (\d+) (\d+))?(?: Loaded from (\S+))?( \(adjourned\))?)?)/);
         if(match) {
           const type = match[1];
           const subtype = match[4];


### PR DESCRIPTION
Update: Once you start finding bugs, they all start appearing at once.

Variuous regex's were failing for users with ratings < 1000
due to leading spaces in the rating string, e.g. ( 950), including notifications for sending and receiving match requests
to / from these players.

Also found a bug where examineGame was not working for games in the History if the ids were single digit, due to a leading space. 

Fxed an annoying bug where the Engine's best move arrow on the board was not disappearing when starting a new game if the tab was not currently visible in the browser. (The arrow was staying there for the entire game).

Fixed possible race condition when reloading page after service worker update