### PR TITLE
Move rating icons

### DIFF
--- a/src/assets/css/application.css
+++ b/src/assets/css/application.css
@@ -1032,6 +1032,25 @@ input[type="number"]:focus {
   color: var(--bs-secondary-color, #6c757d);
 }
 
+.eye-toggle {
+  --eye-toggle-icon-width: 1.125rem;
+}
+.eye-toggle label {
+  white-space: nowrap;
+  --bs-btn-hover-border-color: transparent;
+  --bs-btn-border-color: transparent;
+  --bs-btn-active-border-color: transparent;
+}
+.eye-toggle-icon {
+  display: inline-block; 
+  width: var(--eye-toggle-icon-width);  
+  margin-right: 0.5rem;
+} 
+.eye-toggle-help {
+  margin-top: -0.25rem; 
+  margin-left: calc(var(--eye-toggle-icon-width) + 1.25rem);
+}
+
 #settings-tabs {
   flex-wrap: wrap;
   row-gap: 0.25rem;
@@ -1306,3 +1325,66 @@ input[type="number"]:focus {
   }
 }
 
+.eval-icon {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 12.5%;
+  height: 12.5%;
+  pointer-events: none;
+  z-index: 3;
+}
+.eval-icon::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 30%;
+  height: 30%;
+  transform: translate(50%, -50%);
+  border-radius: 50%;
+  background-color: var(--eval-icon-bg); 
+  box-shadow:
+    inset 0 0.5px 0.75px rgba(255, 255, 255, 0.25),
+    inset 0 0 0 0.75px rgba(255, 255, 255, 0.18),
+    inset 0 -0.75px 1px rgba(0, 0, 0, 0.45),
+    0 1px 1.25px rgba(0, 0, 0, 0.35);
+}
+.eval-icon::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 20%;
+  height: 20%;
+  transform: translate(50%, -50%);
+  background-color: white;
+  -webkit-mask: var(--eval-icon-url) center / contain no-repeat;
+  mask: var(--eval-icon-url) center / contain no-repeat; 
+  pointer-events: none;
+}
+
+.eval-icon-book {
+  --eval-icon-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path d="M320 205.3L320 514.6L320.5 514.4C375.1 491.7 433.7 480 492.8 480L512 480L512 160L492.8 160C450.6 160 408.7 168.4 369.7 184.6C352.9 191.6 336.3 198.5 320 205.3zM294.9 125.5L320 136L345.1 125.5C391.9 106 442.1 96 492.8 96L528 96C554.5 96 576 117.5 576 144L576 496C576 522.5 554.5 544 528 544L492.8 544C442.1 544 391.9 554 345.1 573.5L332.3 578.8C324.4 582.1 315.6 582.1 307.7 578.8L294.9 573.5C248.1 554 197.9 544 147.2 544L112 544C85.5 544 64 522.5 64 496L64 144C64 117.5 85.5 96 112 96L147.2 96C197.9 96 248.1 106 294.9 125.5z"/></svg>');
+  --eval-icon-bg: #1E9E55;
+}
+.eval-icon-best {
+  --eval-icon-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path d="M341.5 45.1C337.4 37.1 329.1 32 320.1 32C311.1 32 302.8 37.1 298.7 45.1L225.1 189.3L65.2 214.7C56.3 216.1 48.9 222.4 46.1 231C43.3 239.6 45.6 249 51.9 255.4L166.3 369.9L141.1 529.8C139.7 538.7 143.4 547.7 150.7 553C158 558.3 167.6 559.1 175.7 555L320.1 481.6L464.4 555C472.4 559.1 482.1 558.3 489.4 553C496.7 547.7 500.4 538.8 499 529.8L473.7 369.9L588.1 255.4C594.5 249 596.7 239.6 593.9 231C591.1 222.4 583.8 216.1 574.8 214.7L415 189.3L341.5 45.1z"/></svg>');
+  --eval-icon-bg: #2F5FA7;
+}
+.eval-icon-ok {
+  --eval-icon-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path d="M530.8 134.1C545.1 144.5 548.3 164.5 537.9 178.8L281.9 530.8C276.4 538.4 267.9 543.1 258.5 543.9C249.1 544.7 240 541.2 233.4 534.6L105.4 406.6C92.9 394.1 92.9 373.8 105.4 361.3C117.9 348.8 138.2 348.8 150.7 361.3L252.2 462.8L486.2 141.1C496.6 126.8 516.6 123.6 530.9 134z"/></svg>');
+  --eval-icon-bg: #6FA84F;
+}
+.eval-icon-inaccuracy {
+  --eval-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1000 1000'%3E%3Csvg x='0' y='0' width='1000' height='1000' viewBox='0 0 920 640' preserveAspectRatio='none'%3E%3Cdefs%3E%3Cpath id='question-mark' d='M224 224C224 171 267 128 320 128C373 128 416 171 416 224C416 266.7 388.1 302.9 349.5 315.4C321.1 324.6 288 350.7 288 392L288 416C288 433.7 302.3 448 320 448C337.7 448 352 433.7 352 416L352 392C352 390.3 352.6 387.9 355.5 384.7C358.5 381.4 363.4 378.2 369.2 376.3C433.5 355.6 480 295.3 480 224C480 135.6 408.4 64 320 64C231.6 64 160 135.6 160 224C160 241.7 174.3 256 192 256C209.7 256 224 241.7 224 224zM320 576C342.1 576 360 558.1 360 536C360 513.9 342.1 496 320 496C297.9 496 280 513.9 280 536C280 558.1 297.9 576 320 576z'/%3E%3Cpath id='exclaimation-mark' d='M320 496C342.1 496 360 513.9 360 536C360 558.1 342.1 576 320 576C297.9 576 280 558.1 280 536C280 513.9 297.9 496 320 496zM320 64C346.5 64 368 85.5 368 112C368 112.6 368 113.1 368 113.7L352 417.7C351.1 434.7 337 448 320 448C303 448 289 434.7 288 417.7L272 113.7C272 113.1 272 112.6 272 112C272 85.5 293.5 64 320 64z'/%3E%3C/defs%3E%3Cg transform='translate(460,320) scale(1.1) translate(-460,-320)'%3E%3Cuse href='%23question-mark'/%3E%3Cuse href='%23exclaimation-mark' transform='translate(320, 0)'/%3E%3C/g%3E%3C/svg%3E%3C/svg%3E");
+  --eval-icon-bg: #C39A06;
+}
+.eval-icon-mistake {
+  --eval-icon-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path d="M224 224C224 171 267 128 320 128C373 128 416 171 416 224C416 266.7 388.1 302.9 349.5 315.4C321.1 324.6 288 350.7 288 392L288 416C288 433.7 302.3 448 320 448C337.7 448 352 433.7 352 416L352 392C352 390.3 352.6 387.9 355.5 384.7C358.5 381.4 363.4 378.2 369.2 376.3C433.5 355.6 480 295.3 480 224C480 135.6 408.4 64 320 64C231.6 64 160 135.6 160 224C160 241.7 174.3 256 192 256C209.7 256 224 241.7 224 224zM320 576C342.1 576 360 558.1 360 536C360 513.9 342.1 496 320 496C297.9 496 280 513.9 280 536C280 558.1 297.9 576 320 576z"/></svg>');
+  --eval-icon-bg: #C65A11;
+}
+.eval-icon-blunder {
+  --eval-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1000 1000'%3E%3Csvg x='0' y='0' width='1000' height='1000' viewBox='0 0 1000 640' preserveAspectRatio='none'%3E%3Cdefs%3E%3Cpath id='icon' d='M224 224C224 171 267 128 320 128C373 128 416 171 416 224C416 266.7 388.1 302.9 349.5 315.4C321.1 324.6 288 350.7 288 392L288 416C288 433.7 302.3 448 320 448C337.7 448 352 433.7 352 416L352 392C352 390.3 352.6 387.9 355.5 384.7C358.5 381.4 363.4 378.2 369.2 376.3C433.5 355.6 480 295.3 480 224C480 135.6 408.4 64 320 64C231.6 64 160 135.6 160 224C160 241.7 174.3 256 192 256C209.7 256 224 241.7 224 224zM320 576C342.1 576 360 558.1 360 536C360 513.9 342.1 496 320 496C297.9 496 280 513.9 280 536C280 558.1 297.9 576 320 576z'/%3E%3C/defs%3E%3Cg transform='translate(500,320) scale(1.1) translate(-500,-320)'%3E%3Cuse href='%23icon'/%3E%3Cuse href='%23icon' transform='translate(360, 0)'/%3E%3C/g%3E%3C/svg%3E%3C/svg%3E%0A");
+  --eval-icon-bg: #B83225;
+}

--- a/src/assets/css/application.css
+++ b/src/assets/css/application.css
@@ -146,12 +146,26 @@ body {
   text-align: center;
 }
 
-#game-requests {
+.dialog-container {
   width: 100%;
   height: 100%;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  z-index: 100;
+}
+
+#fixed-dialog-container {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  top: 50%; 
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 101;
 }
 
 .game-status {
@@ -1168,6 +1182,7 @@ input[type="number"]:focus {
 
 #shortcuts-list {
   position: static;
+  align-self: stretch;
   flex: 1 1 auto;
   min-width: 0;
   max-height: 340px;

--- a/src/assets/css/themes/base-theme-dark.css
+++ b/src/assets/css/themes/base-theme-dark.css
@@ -384,6 +384,7 @@ a {
 .notification-panel {
   --bs-toast-bg: #333333;
   --bs-toast-border-color: #303030;
+  --bs-toast-header-border-color: rgba(0, 0, 0, 0.05);
 }
 #notifications-header {
   --bs-toast-bg: #383838;

--- a/src/assets/css/themes/base-theme-dark.css
+++ b/src/assets/css/themes/base-theme-dark.css
@@ -422,8 +422,11 @@ a {
   color: white;
 }
 
+.modal-table {
+  --bs-emphasis-color: var(--bs-body-color);
+}
 .modal-table thead {
-  background: color-mix(in srgb, var(--bg-color) 85%, white 15%);
+  --bs-table-bg: color-mix(in srgb, var(--bg-color) 85%, white 15%);
   --box-shadow-color: color-mix(in srgb, var(--bg-color) 85%, white 15%);
 }
 

--- a/src/assets/css/themes/base-theme-light.css
+++ b/src/assets/css/themes/base-theme-light.css
@@ -330,8 +330,11 @@ cg-board {
   color: white;
 }
 
+.modal-table {
+  --bs-emphasis-color: var(--bs-body-color);
+}
 .modal-table thead {
-  background: color-mix(in srgb, var(--bg-color) 40%, white 60%);
+  --bs-table-bg: color-mix(in srgb, var(--bg-color) 40%, white 60%);
   --box-shadow-color: color-mix(in srgb, var(--bg-color) 85%, black 15%);
 }
 

--- a/src/assets/css/themes/base-theme-light.css
+++ b/src/assets/css/themes/base-theme-light.css
@@ -313,6 +313,7 @@ cg-board {
 .notification-panel {
   --bs-toast-bg: white;
   --bs-toast-border-color: #DDDDDD;
+  --bs-toast-header-border-color: rgba(0, 0, 0, 0.05);
 }
 #notifications-header {
   --bs-toast-bg: ghostwhite;

--- a/src/js/chat.ts
+++ b/src/js/chat.ts
@@ -283,6 +283,7 @@ export class Chat {
         return;
 
       $('#collapse-chat').addClass('show');
+      $('#collapse-chat').trigger('show.bs.collapse');
       $('#secondary-board-area').hide();
       menuItem.find('.menu-label').text('Unmaximize Chat');
     }
@@ -757,17 +758,16 @@ export class Chat {
 
     const tabElement = this.createTab(tabName);
     let who = '';
-    if (data.user !== undefined) {
-      let textclass = '';
-      if (this.user === data.user) 
-        textclass = ' class="mine"';
-      else
-        textclass = ' class="clickable-user"'
+    if(data.user !== undefined) {
+      let textclass = 'class="clickable-user"'
+      if(this.user === data.user) 
+        textclass += ' class="mine"';
+
       let prompt = data.user;
       if (!settings.chattabsToggle && data.channel !== undefined) {
         prompt += `(${data.channel})`;
       }
-      who = `<strong${textclass}>${$('<span/>').text(prompt).html()}</strong>: `;
+      who = `<strong ${textclass}>${$('<span/>').text(prompt).html()}</strong>: `;
     }
 
     let text = data.message;

--- a/src/js/chess-helper.ts
+++ b/src/js/chess-helper.ts
@@ -1120,16 +1120,17 @@ export function moveToCoordinateString(move: any): string {
  * @param boardRect The board element's bounding rect
  * @param the square coordinates, e.g "e4"
  * @param orientation the way the board is facing, "w" or "b"
+ * @param local if true coordinates are relative to (0, 0). If false, the bounding rect represents screen coordinates.
  * @returns the square's bounding rect 
  */
-export function getSquareRect(boardRect: DOMRect, square: string, orientation: string): DOMRect {
+export function getSquareRect(boardRect: DOMRect, square: string, orientation: string, local = false): DOMRect {
   const file = square.charAt(0).toLowerCase();
   const rank = square.charAt(1);
   const colIndex = orientation === 'w' ? file.charCodeAt(0) - 'a'.charCodeAt(0) : 7 - (file.charCodeAt(0) - 'a'.charCodeAt(0));
   const rowIndex = orientation === 'w' ? 8 - parseInt(rank, 10) : parseInt(rank, 10) - 1;
   const squareSize = boardRect.width / 8;
-  const top = boardRect.top + squareSize * rowIndex;
-  const left = boardRect.left + squareSize * colIndex;
+  const top = (local ? 0 : boardRect.top) + squareSize * rowIndex;
+  const left = (local ? 0 : boardRect.left) + squareSize * colIndex;
   return new DOMRect(left, top, squareSize, squareSize);
 }
 

--- a/src/js/dialogs.ts
+++ b/src/js/dialogs.ts
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a GPL-style
 // license that can be found in the LICENSE file.
 
-import { getTouchClickCoordinates, createTooltip } from './utils';
+import { getTouchClickCoordinates, createTooltip, isSmallWindow } from './utils';
 import { settings } from './settings';
 import { games } from './game';
 
@@ -13,33 +13,6 @@ let dialogCounter = 0;
  **************************************/
 
 /** DIALOG FUNCTIONS **/
-
-export function showBoardDialog(params: DialogParams): any {
-  const dialog = createDialog(params);
-  dialog.appendTo($('#game-requests'));
-  dialog.addClass('board-dialog');
-  dialog.toast('show');
-
-  dialog.on('hidden.bs.toast', function () {
-    $(this).remove();
-  });
-
-  return dialog;
-}
-
-export function showFixedDialog(params: DialogParams): any {
-  const dialog = createDialog(params);
-  const container = $('<div class="toast-container position-fixed top-50 start-50 translate-middle" style="z-index: 101">');
-  container.appendTo('body');
-  dialog.appendTo(container);
-  dialog.toast('show');
-
-  dialog.on('hidden.bs.toast', function () {
-    $(this).parent().remove();
-  });
-
-  return dialog;
-}
 
 export interface DialogParams {
   type?: string;
@@ -53,10 +26,80 @@ export interface DialogParams {
   htmlMsg?: boolean;
 }
 
+/** 
+ * Display a dialog 
+ * @param params The params of the dialog to display
+ * @param position A string indicating where on the screen the dialog should be placed.
+ * Options include: menus, board, chat to place the dialog over the left menus, main board or chat.
+ * top, bottom, middle to fix the dialog to the top, middle or bottom of the screen.
+ * 'modal' which is similar to 'middle' but displays the dialog above any modals showing.
+ * or 'game' which is intended for dialogs displayed when the user is playing a game, which are placed close
+ * to the board but not covering it. On desktop, 'game' dialogs are placed to the left of the board, 
+ * on mobile, they are fixed to the top of the screen. 
+ */
+export function showDialog(params: DialogParams, position = 'middle'): any {
+  const dialog = createDialog(params);
+
+  if(position === 'game') {
+    position = (isSmallWindow() ? 'top' : 'menus');  
+    dialog.addClass('game-dialog');
+  }
+
+  let containerID = null;
+  switch(position) {
+    case 'menus': 
+      containerID = '#left-col';
+      dialog.addClass('menus-dialog');
+      break;
+    case 'board':
+      containerID = '#mid-col';
+      dialog.addClass('board-dialog');
+      break;
+    case 'chat':
+      dialog.addClass('chat-dialog');
+      containerID = '#right-col';
+      break;
+  }
+
+  if(containerID)
+    dialog.appendTo($(`${containerID} .dialog-container`));
+  else if(position === 'modal') {
+    dialog.css({
+      position: 'fixed',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+      'z-index': '1056',
+    });
+    dialog.addClass('above-modal-dialog');
+    dialog.appendTo('body');    
+  }
+  else if(position === 'top' || position === 'bottom') {
+    dialog.css({
+      position: 'fixed',
+      ...(position === 'top' && { top: '0' }),
+      ...(position === 'bottom' && { bottom: '0' }),
+      left: '50%',
+      transform: 'translate(-50%)',
+      'z-index': '101',
+    });
+    dialog.appendTo('body');
+  }
+  else
+    dialog.appendTo($('#fixed-dialog-container'));
+  
+  dialog.toast('show');
+  dialog.on('hidden.bs.toast', function () {
+    $(this).remove();
+  });
+
+  return dialog;
+}
+
 export function createDialog({type = '', title = '', msg = '', btnFailure, btnSuccess, useSessionSend = false, icons = true, progress = false, htmlMsg = false}: DialogParams): JQuery<HTMLElement> {
   const dialogId = `dialog${dialogCounter++}`;
   let req = `
-  <div id="${dialogId}" class="toast" data-bs-autohide="false" role="status" aria-live="polite" aria-atomic="true">
+  <div id="${dialogId}" class="toast dialog" data-bs-autohide="false" role="status" aria-live="polite" aria-atomic="true">
     <div class="toast-header">
       <strong class="header-text me-auto">${type}</strong>
       <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
@@ -133,7 +176,7 @@ export function createDialog({type = '', title = '', msg = '', btnFailure, btnSu
 }
 
 export function showInfoDialog(title: string, text: string) {
-  const dialog = $(`<div class="toast info-dialog" data-bs-autohide="false" role="status" aria-live="polite" aria-atomic="true">
+  const dialog = $(`<div class="toast dialog info-dialog" data-bs-autohide="false" role="status" aria-live="polite" aria-atomic="true">
     <div class="toast-header">
       <strong class="header-text me-auto">${title}</strong>
       <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
@@ -141,6 +184,8 @@ export function showInfoDialog(title: string, text: string) {
     <div class="toast-body font-monospace" style="max-height: 500px; overflow: auto; white-space: pre-wrap">${text}</div>
   </div>`);
   const modal = $('.modal.show');
+  if(modal.length)
+    dialog.addClass('above-modal-dialog');
   dialog.appendTo(modal.length ? modal : 'body');
   dialog.toast('show');
 }
@@ -155,6 +200,7 @@ export function createNotification(params: DialogParams): any {
   dialog.on('click', 'button', () => {
     removeNotification(dialog);
   });
+  dialog.removeClass('dialog');
   dialog.addClass('notification');
   dialog.addClass('notification-panel');
   $('#notifications-btn').prop('disabled', false);

--- a/src/js/engine.ts
+++ b/src/js/engine.ts
@@ -23,12 +23,13 @@ export class Engine {
   public stopping: boolean = false; // Has 'stop' command been called? Ignore any late 'info' messages
   protected currFen: string;
   protected currEval: string;
+  protected currNodes: number;
   protected game: Game;
-  protected bestMoveCallback: (game: Game, move: string, score: string) => void;
-  protected pvCallback: (game: Game, pvNum: number, pvEval: string, pvMoves: string) => void;
+  protected bestMoveCallback: (game: Game, move: string, score: string, nodes: number) => void;
+  protected pvCallback: (game: Game, pvNum: number, pvEval: string, pvMoves: string, pvNodes: number) => void;
   protected moveParams: string;
   
-  constructor(game: Game, bestMoveCallback: (game: Game, move: string, score: string) => void, pvCallback: (game: Game, pvNum: number, pvEval: string, pvMoves: string) => void, engineName: string, options?: object, moveParams?: string) {
+  constructor(game: Game, bestMoveCallback: (game: Game, move: string, score: string, nodes: number) => void, pvCallback: (game: Game, pvNum: number, pvEval: string, pvMoves: string, pvNodes: number) => void, engineName: string, options?: object, moveParams?: string) {
     this.moveParams = moveParams;
     this.currFen = null;
     this.game = game;
@@ -76,6 +77,7 @@ export class Engine {
           const pvArr = [];
           let scoreStr: string;
           let pvNum = 1;
+          this.currNodes = 0;
           for(let i = 0; i < infoArr.length; i++) {
             if(infoArr[i] === 'lowerbound' || infoArr[i] === 'upperbound')
               return;
@@ -113,6 +115,8 @@ export class Engine {
               else
                 scoreStr = `${prefix}${(score / 100).toFixed(2)}`;
             }
+            else if(infoArr[i] === 'nodes')
+              this.currNodes = +infoArr[i+1];
             else if(infoArr[i] === 'pv')
               bPV = true;
             else if(bPV)
@@ -150,18 +154,18 @@ export class Engine {
             }
 
             if(this.pvCallback)
-              this.pvCallback(this.game, pvNum, scoreStr, pv);
+              this.pvCallback(this.game, pvNum, scoreStr, pv, this.currNodes);
           }
           // mate in 0
           else if(scoreStr === '#0' || scoreStr === '-#0') {
             if(this.pvCallback)
-              this.pvCallback(this.game, 1, scoreStr, '');
+              this.pvCallback(this.game, 1, scoreStr, '', this.currNodes);
           }
           this.currEval = scoreStr;
 
           // For backwards compatibility, older version of Stockfish didn't send a bestmove for mate in 0.
           if(depth0 && this.bestMoveCallback)
-            this.bestMoveCallback(this.game, '', this.currEval);
+            this.bestMoveCallback(this.game, '', this.currEval, this.currNodes);
         }
         else if(response.data.startsWith('bestmove')) {
           if(this.stopping) {
@@ -173,7 +177,7 @@ export class Engine {
           if(this.bestMoveCallback) {
             const bestMove = response.data.trim().split(/\s+/)[1];
             if(bestMove !== '(none)')
-              this.bestMoveCallback(this.game, bestMove, this.currEval);
+              this.bestMoveCallback(this.game, bestMove, this.currEval, this.currNodes);
           }
         }
       };
@@ -403,8 +407,10 @@ export class EvalEngine extends Engine {
     this.bestMoveCallback = this.bestMove;
   }
 
-  public bestMove(game: Game, move: string, score: string) {
+  public bestMove(game: Game, move: string, score: string, nodes: number) {
     this.currMove.eval = score;
+    this.currMove.evalNodes = nodes;
+    this.currMove.evalBestMove = move;
     this.currMove = undefined;
     this._redraw = true;
     this.evaluate();
@@ -681,6 +687,95 @@ export class EvalEngine extends Engine {
         currMoveCircle
           .css('opacity', 0);
     }
+  }
+
+  /**
+   * Scores a move based on its engine eval relative to a reference eval (usually the Engine's best move).
+   * The function is weighted so that moves which would cause a transition from equal to losing, or winning to
+   * equal etc are given a much bigger negative score than those which don't change the overall outcome.
+   * Current calibration:
+   * 0 to -0.5 ok move
+   * -0.5 to -1 inaccuracy
+   * -1 to -3 mistake
+   * < -3 blunder 
+   * @param evaluation The engine's centi-pawn eval for the move
+   * @param reference The reference eval (usually engine's best move)
+   * @param turnColor The side who made the move
+   * @returns a score, usually < 0
+   */
+  public static scoreMove(evaluation: string, reference: string, turnColor: string) {  
+    // Piece-wise sensitivity function for scoring intervals along an eval curve.
+    // This can be visualised as a curve with 2 peaks centered at eval 2.5 and -2.5
+    // with a valley at 0 eval and flat tails beyond an eval of 3.
+    // E.g. an eval change from 5 to 3 has a score close to 0 since it doesn't change the expected
+    // outcome of the game, whereas a change from 2 to 0 has a much bigger score, since it goes from
+    // winning to equal. Only the positive side of the curve is defined, but it is treated as
+    // symmetrical around 0
+    const bands = [
+      { start: 5, end: 10, weight: 0.05 },
+      { start: 3, end: 5, weight: 0.25 },
+      { start: 2, end: 3, weight: 1.75 },
+      { start: 1, end: 2, weight: 1.5 },
+      { start: 0, end: 1, weight: 1 },
+    ];
+    
+    evaluation.replace('=', '');
+    reference.replace('=', '');
+
+    // Treat all "mate in X" as having an eval of 10
+    if(evaluation.includes('#')) 
+      evaluation = (evaluation[0] === '-' ? '-10' : '+10');
+    if(reference.includes('#')) 
+      reference = (reference[0] === '-' ? '-10' : '+10');
+
+    const evalNum = +evaluation;
+    const refNum = +reference;
+
+    /**
+     * Returns the length of the overlap between two intervals.
+     * @param a One end of the given interval (eval difference)
+     * @param b Other end of the given interval 
+     * @param start Start of the band interval (sensitivity function)
+     * @param end: End of the band interval
+     */
+    const overlap = (a: number, b: number, bandA: number, bandB: number) => {
+      const lo = Math.min(a, b);
+      const hi = Math.max(a, b);
+      const bandLo = Math.min(bandA, bandB);
+      const bandHi = Math.max(bandA, bandB);
+      return Math.max(0, Math.min(hi, bandHi) - Math.max(lo, bandLo));
+    };
+
+    // A negative eval change produces a negative score for white, but positive score for black
+    const sign = Math.sign(evalNum - refNum) * (turnColor === 'w' ? 1 : -1);
+
+    const score = sign * bands.reduce((acc, band) => {
+      // positive bands
+      let o = overlap(evalNum, refNum, band.start, band.end);
+      // mirrored negative bands
+      o += overlap(-evalNum, -refNum, band.start, band.end);
+      return acc + o * band.weight;
+    }, 0);
+
+    return score;
+  }
+
+  /**
+   * Rates a move based on its engine eval relative to a reference eval (usually the Engine's best move).
+   * Rating is a string which describes the quality of the move. 
+   * See scoreMove for more info.
+   */
+  public static rateMove(evaluation: string, reference: string, turnColor: string) {
+    const score = this.scoreMove(evaluation, reference, turnColor);
+
+    if(score < -3)
+      return 'blunder';
+    else if(score < -1)
+      return 'mistake';
+    else if(score < -0.5)
+      return 'inaccuracy';
+    else 
+      return 'ok';
   }
 }
 

--- a/src/js/history.ts
+++ b/src/js/history.ts
@@ -1404,7 +1404,8 @@ export class History {
       TimeControl: timeControl,
       WhiteElo: (game.wname ? game.wrating || '-' : '?'),
       BlackElo: (game.bname ? game.brating || '-' : '?'),
-      Time: time,
+      UTCDate: date,
+      UTCTime: time,
       Variant: game.category,
       ...(isSetupPosition && { SetUp: '1', FEN: game.fen })
     }, true);

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -107,6 +107,8 @@ let oldEngineName: string = '';
 let oldEngineMaxTime: number;
 let oldEngineThreads: number;
 let oldEngineMemory: number;
+let bestMoveBrush = 'yellow';
+let prevBestMoveBrush = 'purple';
 let lastOpponent: string = ''; // The opponent of the current or last game played 
 let prevSizeCategory = null;
 let layout = Layout.Desktop;
@@ -857,7 +859,10 @@ function setGameCardSize(game: Game, cardMaxWidth?: number, cardMaxHeight?: numb
   // Set card width
   const cardBorderWidth = card.outerWidth() - card.width();
   card.width(cardWidth - cardBorderWidth);
-  game.board.redrawAll();
+  
+  setTimeout(() => {
+    game.board.redrawAll(); // Redraw board coordinates
+  }, 0);
 
   return { width: cardWidth, height: cardHeight }
 }
@@ -2952,7 +2957,7 @@ export function updateBoard(game: Game, playMove = false, setBoard = true, anima
 
   setClocks(game);
 
-  const premoveSquares = new Map();
+  const squareClasses = new Map();
 
   if((setBoard || game.setupBoard) && game.element.find('.promotion-panel').is(':visible')) {
     game.board.cancelPremove();
@@ -2967,9 +2972,9 @@ export function updateBoard(game: Game, playMove = false, setBoard = true, anima
       for(let i = 0; i < game.premoves.length; i++) {
         const premove = game.premoves[i];
         // Set premove square highlighting and numbering classes
-        if(premove.from && !premoveSquares.get(premove.from))
-          premoveSquares.set(premove.from, 'current-premove');
-        premoveSquares.set(premove.to, `current-premove premove-target premove-square-${premove.to}`);
+        if(premove.from && !squareClasses.get(premove.from))
+          squareClasses.set(premove.from, 'current-premove');
+        squareClasses.set(premove.to, `current-premove premove-target premove-square-${premove.to}`);
       }
     }   
 
@@ -3027,7 +3032,7 @@ export function updateBoard(game: Game, playMove = false, setBoard = true, anima
     highlight: {
       lastMove: settings.highlightsToggle,
       check: settings.highlightsToggle,
-      custom: premoveSquares
+      custom: squareClasses
     },
     predroppable: { enabled: game.category === 'crazyhouse' || game.category === 'bughouse' },
     check: !game.setupBoard && /[+#]/.test(move?.san) ? color : false,
@@ -3039,6 +3044,7 @@ export function updateBoard(game: Game, playMove = false, setBoard = true, anima
   showCapturedMaterial(game);
   showOpeningName(game);
   updateBoardStatusText();
+  updateMoveRatingIcon(game);
 
   if(playMove && !checkAtomicCapture(game) && settings.soundToggle && game === games.focused) {
     clearTimeout(soundTimer);
@@ -3637,6 +3643,8 @@ function flipBoard(game: Game) {
   if(game.element.find('.promotion-panel').is(':visible'))
     showPromotionPanel(game);
 
+  positionMoveRatingIcon(game);
+
   // Swap player and opponent status panels
   if(game.element.find('.white-status').parent().hasClass('top-panel')) {
     game.element.find('.white-status').appendTo(game.element.find('.bottom-panel'));
@@ -3813,8 +3821,9 @@ function updateHistory(game: Game, move?: any, fen?: string, serverIssued = true
   }
 
   if(game.isObserving() && game.history.current() !== game.history.last() && serverIssued) {
-    game.history.highlightMove();
     updateBoard(game, false, false);
+    if(evalEngine)
+      evalEngine.evaluate();
     return; // User is currently viewing an earlier move in the move list, so don't display the new move
   }
 
@@ -3918,7 +3927,7 @@ export function setGameWithFocus(game: Game) {
       games.focused.moveTableElement.hide();
       games.focused.moveListElement.hide();
       games.focused.statusElement.hide();
-      games.focused.board.setAutoShapes([]);
+      removeAutoShape(games.focused, bestMoveBrush);
     }
 
     game.moveTableElement.show();
@@ -7187,8 +7196,10 @@ function showAnalysis() {
 }
 
 function hideAnalysis() {
+  removeAutoShape(games.focused, prevBestMoveBrush);
   stopEngine();
   stopEvalEngine();
+  removeMoveRatingIcon(games.focused);
   closeLeftBottomTab($('#engine-tab'));
   closeLeftBottomTab($('#eval-graph-tab'));
   showAnalyzeButton();
@@ -7281,8 +7292,7 @@ function stopEngine(temporary = false) {
       engine = null;
     }
 
-    game.board.setAutoShapes([]); 
-    game.board.redrawAll();
+    removeAutoShape(game, bestMoveBrush); 
     
     if(!temporary) {
       game.element.find('.eval-bar').hide();
@@ -7332,21 +7342,33 @@ $('#remove-pv').on('click', () => {
   }
 });
 
-function displayEnginePV(game: Game, pvNum: number, pvEval: string, pvMoves: string) {
+function displayEnginePV(game: Game, pvNum: number, pvEval: string, pvMoves: string, pvNodes: number) {
   $('#engine-pvs li').eq(pvNum - 1).html(`<b>(${pvEval})</b> ${pvMoves}<b/>`);
 
   if(pvNum === 1 && pvMoves) {
+    const currHEntry = game.history.current();
     const words = pvMoves.split(/\s+/);
     const san = words[0].split(/\.+/)[1];
-    const fen = game.setupBoard ? getSetupBoardFEN(game) : game.history.current().fen; 
+    const fen = game.setupBoard ? getSetupBoardFEN(game) : currHEntry.fen; 
     const parsed = parseGameMove(game, fen, san);
-    if(settings.bestMoveArrowToggle) {
-      game.board.setAutoShapes([{
+    if(settings.bestMoveArrowToggle && settings.engineBoardVisualsToggle) {
+      removeAutoShape(game, bestMoveBrush);      
+      let autoShapes = game.board.state.drawable.autoShapes;
+      autoShapes.push({ 
         orig: parsed.move.from || parsed.move.to, // For crazyhouse, just draw a circle on dest square
         dest: parsed.move.to,
-        brush: 'yellow',
-      }]);
+        brush: bestMoveBrush
+      });
+      game.board.setAutoShapes(autoShapes);
     }
+
+    if(!game.setupBoard && (!currHEntry.evalNodes || pvNodes >= currHEntry.evalNodes)) {
+      currHEntry.eval = pvEval;
+      currHEntry.evalBestMove = san[1] === '@' ? san : `${parsed.move.from}${parsed.move.to}`;
+      currHEntry.evalNodes = pvNodes;
+      debounceUpdateMoveRatingIcon(game);
+    }
+    
     updateEvalBar(game, pvEval);
   }
 }
@@ -7535,6 +7557,96 @@ function stopEvalEngine() {
   evalEngine?.terminate();
   evalEngine = null;
 }
+
+const debounceUpdateMoveRatingIcon = Utils.debounce(updateMoveRatingIcon, 250);
+/**
+ * Adds a move rating icon to the corner of a square on the board, indicating the previous move's
+ * quality, e.g. inaccuracy, mistake, blunder, best engine move (star), book move.
+ * Also optionally adds an arrow showing the engine's best alternative to the move (Previous Best Move Arrow). 
+ */
+async function updateMoveRatingIcon(game: Game) {
+  const curr = game.history.current();
+  const prev = game.history.prev();
+  const square = curr.move?.to;
+
+  if(!game.setupBoard && game.analyzing && curr.eval != null && prev?.eval != null) {
+    let rating = '';
+    if((await getBookMoves(curr.fen)).length) 
+      rating = 'book';
+    else {
+      const mv = curr.move.san[1] === '@' ? curr.move.san : `${curr.move.from}${curr.move.to}`;
+      rating = (mv === prev.evalBestMove)
+        ? 'best'
+        : EvalEngine.rateMove(curr.eval, prev.eval, ChessHelper.swapColor(curr.turnColor));
+    }
+
+    // If the current move changed while we were looking up the opening book then bail out.
+    if(game.setupBoard || !game.analyzing || curr !== game.history?.current() || prev !== game.history?.prev())
+      return;
+    
+    removeMoveRatingIcon(game);
+
+    if(settings.moveRatingIconToggle && settings.engineBoardVisualsToggle) {
+      // Add new 'eval-icon'
+      const icon = $(`<square data-coords="${square}" class="eval-icon eval-icon-${rating}"></square>`);
+      game.element.find('.board-container').append(icon);
+      positionMoveRatingIcon(game);
+    }
+
+    // If current move is not the best move then indicate the alternative best move with an arrow
+    if(rating !== 'book' && rating !== 'best' 
+        && settings.prevBestMoveArrowToggle && settings.engineBoardVisualsToggle) {
+      const bestMove = prev.evalBestMove;
+      const dest = bestMove.slice(2,4);
+      const orig = bestMove[1] === '@' ? dest : bestMove.slice(0,2);
+      removeAutoShape(game, prevBestMoveBrush);  
+      let autoShapes = game.board.state.drawable.autoShapes;
+      autoShapes.push({ orig, dest, brush: prevBestMoveBrush });
+      game.board.setAutoShapes(autoShapes);
+    }
+  }
+  else {
+    removeMoveRatingIcon(game);
+    removeAutoShape(game, prevBestMoveBrush);
+  }
+}
+
+/**
+ * Position a move rating icon based on its data-coords attribute, e.g. 'e4'.
+ */
+function positionMoveRatingIcon(game: Game) {
+  const icon = game.element.find('.eval-icon');
+  if(icon.length) {
+    const orientation = game.board.state.orientation === 'white' ? 'w' : 'b';
+    const boardRect = game.element.find('.board')[0].getBoundingClientRect();
+    const square = icon.attr('data-coords');
+    const squareRect = ChessHelper.getSquareRect(boardRect, square, orientation, true);
+    const percentLeft = squareRect.left * 100 / boardRect.width;
+    const percentTop = squareRect.top * 100 / boardRect.height; 
+    icon.css({
+      left: `${percentLeft}%`,
+      top: `${percentTop}%`
+    });
+  }
+}
+
+/**
+ * Removes a move rating icon shown on the board.
+ */
+function removeMoveRatingIcon(game: Game) {
+  game.element.find('.eval-icon').remove();
+};
+
+/**
+ * Removes all Chessground AutoShapes from the board which match the specified brush name (usually a color). 
+ */
+function removeAutoShape(game: Game, brush: string) {   
+  let autoShapes = game.board.state.drawable.autoShapes;
+  if(!autoShapes)
+    return;
+  autoShapes = autoShapes.filter(shape => shape.brush !== brush);
+  game.board.setAutoShapes(autoShapes);
+} 
 
 /** STATUS PANEL SHOW/HIDE BUTTON **/
 
@@ -7808,15 +7920,40 @@ function initSettings() {
   settings.smartmoveToggle = (storage.get('smartmove') === 'true');
   $('#smartmove-toggle').prop('checked', settings.smartmoveToggle);
 
-  settings.evalBarToggle = (storage.get('evalbar') !== 'false');
-  $('#eval-bar-toggle').prop('checked', settings.evalBarToggle);
-  $('#eval-bar-toggle-icon').toggleClass('fa-eye', settings.evalBarToggle);
-  $('#eval-bar-toggle-icon').toggleClass('fa-eye-slash', !settings.evalBarToggle);
+  let setting = storage.get('engineboardvisuals');
+  if(setting != null)
+    settings.engineBoardVisualsToggle = (setting === 'true');
+  $('#engine-board-visuals-toggle').prop('checked', settings.engineBoardVisualsToggle);
+  $('#engine-board-visuals-toggle-icon').toggleClass('fa-eye', settings.engineBoardVisualsToggle);
+  $('#engine-board-visuals-toggle-icon').toggleClass('fa-eye-slash', !settings.engineBoardVisualsToggle);
 
-  settings.bestMoveArrowToggle = (storage.get('bestmovearrow') !== 'false');
+  setting = storage.get('evalbar');
+  if(setting != null)
+    settings.evalBarToggle = (setting === 'true');
+  $('#engine-panel-eval-bar-toggle, #eval-bar-toggle').prop('checked', settings.evalBarToggle);
+  $('#engine-panel-eval-bar-toggle-icon, #eval-bar-toggle-icon').toggleClass('fa-eye', settings.evalBarToggle);
+  $('#engine-panel-eval-bar-toggle-icon, #eval-bar-toggle-icon').toggleClass('fa-eye-slash', !settings.evalBarToggle);
+
+  setting = storage.get('moveratingicon');
+  if(setting != null)
+    settings.moveRatingIconToggle = (setting === 'true');
+  $('#move-rating-toggle').prop('checked', settings.moveRatingIconToggle);
+  $('#move-rating-toggle-icon').toggleClass('fa-eye', settings.moveRatingIconToggle);
+  $('#move-rating-toggle-icon').toggleClass('fa-eye-slash', !settings.moveRatingIconToggle);
+
+  setting = storage.get('bestmovearrow');
+  if(setting != null)
+    settings.bestMoveArrowToggle = (setting === 'true');
   $('#best-move-arrow-toggle').prop('checked', settings.bestMoveArrowToggle);
   $('#best-move-arrow-toggle-icon').toggleClass('fa-eye', settings.bestMoveArrowToggle);
   $('#best-move-arrow-toggle-icon').toggleClass('fa-eye-slash', !settings.bestMoveArrowToggle);
+
+  setting = storage.get('prevbestmovearrow');
+  if(setting != null)
+    settings.prevBestMoveArrowToggle = (setting === 'true');
+  $('#prev-best-move-arrow-toggle').prop('checked', settings.prevBestMoveArrowToggle);
+  $('#prev-best-move-arrow-toggle-icon').toggleClass('fa-eye', settings.prevBestMoveArrowToggle);
+  $('#prev-best-move-arrow-toggle-icon').toggleClass('fa-eye-slash', !settings.prevBestMoveArrowToggle);
 
   const engineName = storage.get('analyze-engine-name');
   if(engineName)
@@ -7933,11 +8070,11 @@ $('#smartmove-toggle').on('click', () => {
   storage.set('smartmove', String(settings.smartmoveToggle));
 });
 
-$('#eval-bar-toggle').on('change', () => {
+$('#engine-panel-eval-bar-toggle, #eval-bar-toggle').on('change', () => {
   settings.evalBarToggle = !settings.evalBarToggle;
 
-  $('#eval-bar-toggle-icon').toggleClass('fa-eye');
-  $('#eval-bar-toggle-icon').toggleClass('fa-eye-slash');
+  $('#engine-panel-eval-bar-toggle-icon, #eval-bar-toggle-icon').toggleClass('fa-eye');
+  $('#engine-panel-eval-bar-toggle-icon, #eval-bar-toggle-icon').toggleClass('fa-eye-slash');
 
   const game = games.focused;
   if(game.engineRunning) {
@@ -7950,6 +8087,22 @@ $('#eval-bar-toggle').on('change', () => {
   storage.set('evalbar', String(settings.evalBarToggle));
 });
 
+$('#move-rating-toggle').on('change', () => {
+  settings.moveRatingIconToggle = !settings.moveRatingIconToggle;
+
+  $('#move-rating-toggle-icon').toggleClass('fa-eye');
+  $('#move-rating-toggle-icon').toggleClass('fa-eye-slash');
+
+  for(const game of games) {
+    if(settings.moveRatingIconToggle) 
+      updateMoveRatingIcon(game);
+    else 
+      removeMoveRatingIcon(game);
+  }
+  
+  storage.set('moveratingicon', String(settings.moveRatingIconToggle));
+});
+
 $('#best-move-arrow-toggle').on('change', () => {
   settings.bestMoveArrowToggle = !settings.bestMoveArrowToggle;
 
@@ -7958,14 +8111,49 @@ $('#best-move-arrow-toggle').on('change', () => {
 
   if(settings.bestMoveArrowToggle) 
     updateEngine();
-  else {
-    if(games.focused.engineRunning) {
-      games.focused.board.setAutoShapes([]); 
-      games.focused.board.redrawAll();
-    }
-  }
+  else if(games.focused.engineRunning) 
+    removeAutoShape(games.focused, bestMoveBrush);  
   
   storage.set('bestmovearrow', String(settings.bestMoveArrowToggle));
+});
+
+$('#prev-best-move-arrow-toggle').on('change', () => {
+  settings.prevBestMoveArrowToggle = !settings.prevBestMoveArrowToggle;
+
+  $('#prev-best-move-arrow-toggle-icon').toggleClass('fa-eye');
+  $('#prev-best-move-arrow-toggle-icon').toggleClass('fa-eye-slash');
+
+  for(const game of games) {
+    if(settings.prevBestMoveArrowToggle) 
+      updateMoveRatingIcon(game);
+    else 
+      removeAutoShape(game, prevBestMoveBrush);  
+  }
+  
+  storage.set('prevbestmovearrow', String(settings.prevBestMoveArrowToggle));
+});
+
+$('#engine-board-visuals-toggle').on('change', () => {
+  settings.engineBoardVisualsToggle = !settings.engineBoardVisualsToggle;
+
+  $('#engine-board-visuals-toggle-icon').toggleClass('fa-eye');
+  $('#engine-board-visuals-toggle-icon').toggleClass('fa-eye-slash');
+
+  for(const game of games) {
+    if(settings.engineBoardVisualsToggle) 
+      updateMoveRatingIcon(game);
+    else {
+      removeMoveRatingIcon(game);
+      removeAutoShape(game, prevBestMoveBrush);  
+    }
+  }
+
+  if(settings.bestMoveArrowToggle) 
+    updateEngine();
+  else if(games.focused.engineRunning) 
+    removeAutoShape(games.focused, bestMoveBrush);  
+
+  storage.set('engineboardvisuals', String(settings.engineBoardVisualsToggle));
 });
 
 /** *****************************
@@ -8191,7 +8379,6 @@ async function playAtomicEffect(game: Game, squares: string[]) {
   const orientation = game.board.state.orientation === 'white' ? 'w' : 'b';
   const destRects = [];
   const canvasRect = canvas.getBoundingClientRect();
-  canvasRect.x = canvasRect.y = 0; // Convert to canvas coordinates
   
   // Get explosion sfx duration in order to sync animation duration with it
   const duration = await Utils.getAudioDuration(Sounds.atomicSound) * 1000;
@@ -8208,7 +8395,7 @@ async function playAtomicEffect(game: Game, squares: string[]) {
   squares.forEach(sq => {
     const sprite: Utils.Sprite = {
       spriteSheet: atomicSprite,
-      destRect: ChessHelper.getSquareRect(canvasRect, sq, orientation),
+      destRect: ChessHelper.getSquareRect(canvasRect, sq, orientation, true),
       frameWidth: 256,
       frameHeight: 256,
       totalFrames: 30,

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -301,7 +301,7 @@ function showActiveSessionPrompt(activeSession: { user: string; tabId: string; t
   const connectHandler = () => {
     session?.reconnect();
   };
-  Dialogs.showFixedDialog({
+  Dialogs.showDialog({
     type: 'Active Session Detected',
     msg: bodyText,
     btnFailure: ['', 'Use active tab'],
@@ -1117,7 +1117,7 @@ function messageHandler(data: any) {
         updateForegroundServiceState();
       }
       else if(data.command === 4) { // Connecting
-        $('#game-requests').empty();
+        $('.game-dialog, .board-dialog').remove();
         $('.not-signed-in-notice').remove();
       }
       break;
@@ -1370,7 +1370,7 @@ function gameStart(game: Game) {
 
   if(game.isPlaying() || game.isExamining()) {
     clearMatchRequests();
-    $('#game-requests').html('');
+    $('.game-dialog, .board-dialog').remove();
     Dialogs.hideAllNotifications();
   }
 
@@ -1581,7 +1581,9 @@ function gameEnd(data: any) {
     if(data.reason !== Reason.Adjourn && data.reason !== Reason.Abort && game.history.length()) 
       analyze = ['analyze();', 'Analyze'];
 
-    Dialogs.showBoardDialog({type: 'Match Result', msg: dialogText, btnFailure: rematch, btnSuccess: analyze, icons: false});
+    $('.game-dialog').remove();
+
+    Dialogs.showDialog({type: 'Match Result', msg: dialogText, btnFailure: rematch, btnSuccess: analyze, icons: false}, 'board');
     if(data.extraText)
       chat.newMessage('console', { message: data.extraText });
     cleanupGame(game);
@@ -1712,7 +1714,7 @@ function handleOffers(offers: any[]) {
       if(displayType === 'notification')
         dialog = Dialogs.createNotification({type: headerTitle, title: bodyTitle, msg: bodyText, btnFailure: [`decline ${item.id}`, 'Decline'], btnSuccess: [`accept ${item.id}`, 'Accept'], useSessionSend: true});
       else if(displayType === 'dialog')
-        dialog = Dialogs.showBoardDialog({type: headerTitle, title: bodyTitle, msg: bodyText, btnFailure: [`decline ${item.id}`, 'Decline'], btnSuccess: [`accept ${item.id}`, 'Accept'], useSessionSend: true});
+        dialog = Dialogs.showDialog({type: headerTitle, title: bodyTitle, msg: bodyText, btnFailure: [`decline ${item.id}`, 'Decline'], btnSuccess: [`accept ${item.id}`, 'Accept'], useSessionSend: true}, 'game');
       dialog.attr('data-offer-id', item.id);
     }
   });
@@ -1736,7 +1738,7 @@ function handleOffers(offers: any[]) {
         }
       }
       Dialogs.removeNotification($(`.notification[data-offer-id="${id}"]`)); // If match request was not ours, remove the Notification
-      $(`.board-dialog[data-offer-id="${id}"]`).toast('hide'); // if in-game request, hide the dialog
+      $(`.game-dialog[data-offer-id="${id}"]`).toast('hide'); // if in-game request, hide the dialog
       $(`.sent-offer[data-offer-id="${id}"]`).remove(); // If offer, match request or seek was sent by us, remove it from the Play pane
       $(`.lobby-entry[data-offer-id="${id}"]`).remove(); // Remove seek from lobby
     });
@@ -1967,9 +1969,15 @@ function handleMiscMessage(data: any) {
       const bodyText = `${tell.recipient} is not logged in. Send as message instead?`;
       const button1 = [okHandler, 'Yes'];
       const button2 = ['', 'No'];
-      Dialogs.showFixedDialog({type: headerTitle, msg: bodyText, btnFailure: button2, btnSuccess: button1});
+      Dialogs.showDialog({type: headerTitle, msg: bodyText, btnFailure: button2, btnSuccess: button1}, 'chat');
       return;
     }
+  }
+
+  if(/^\S+ declines the (draw|abort|takeback|adjourn) request\./m.test(msg)) {
+    Dialogs.showDialog({type: 'Offer Declined', msg}, 'game');
+    chat.newMessage('console', data);
+    return;
   }
 
   match = msg.match(/^Game (\d+): (\S+) has lagged for 30 seconds\./m);
@@ -1977,7 +1985,7 @@ function handleMiscMessage(data: any) {
     const game = games.findGame(+match[1]);
     if(game && game.isPlaying()) {
       const bodyText = `${match[2]} has lagged for 30 seconds.<br>You may courtesy adjourn the game.<br><br>If you believe your opponent has intentionally disconnected, you can request adjudication of an adjourned game. Type 'help adjudication' in the console for more info.`;
-      const dialog = Dialogs.showBoardDialog({type: 'Opponent Lagging', msg: bodyText, btnFailure: ['', 'Wait'], btnSuccess: ['adjourn', 'Adjourn'], useSessionSend: true});
+      const dialog = Dialogs.showDialog({type: 'Opponent Lagging', msg: bodyText, btnFailure: ['', 'Wait'], btnSuccess: ['adjourn', 'Adjourn'], useSessionSend: true}, 'game');
       dialog.attr('data-game-id', game.id);
     }
     chat.newMessage('console', data);
@@ -2024,7 +2032,7 @@ function handleMiscMessage(data: any) {
           break;
         }
       }
-      Dialogs.showFixedDialog({type: 'Unable to Rematch', msg: `Couldn't determine the last type of match played against ${rematchUser}. Use 'Challenge' instead.`, btnSuccess: ['', 'OK']});
+      Dialogs.showDialog({type: 'Unable to Rematch', msg: `Couldn't determine the last type of match played against ${rematchUser}. Use 'Challenge' instead.`, btnSuccess: ['', 'OK']});
     }
     else
       chat.newMessage('console', data);
@@ -2212,7 +2220,7 @@ function handleMiscMessage(data: any) {
 
   match = msg.match(/^(All players must be registered to adjourn a game.  Use "abort".)/m);
   if(match && match.length > 1) {
-    Dialogs.showBoardDialog({type: 'Can\'t Adjourn', msg: match[1]});
+    Dialogs.showDialog({type: 'Can\'t Adjourn', msg: match[1]}, 'game');
     return;
   }
 
@@ -2597,16 +2605,25 @@ function handleMiscMessage(data: any) {
     return;
   }
 
-  if(awaiting.has('notify-list')) {
-    const notifyUsers = parseNotifyList(msg);
-    if(notifyUsers !== null) {
-      awaiting.resolve('notify-list');
-      if(notifyUsers.length)
-        users.addFriendsFromNotify(notifyUsers);
-      return;
+  if(/^-- notify list:/m.test(msg) && awaiting.resolve('notify-list')) {
+    users.notifyList = parseNotifyList(msg);
+    users.addFriendList(users.notifyList.map(name => ({ name })));
+    return;
+  }
+  
+  match = msg.match(/^\[(\w+)\] added to your notify list\./m);
+  if(match) {
+    const user = match[1];
+    if(!users.notifyList.includes(user)) {
+      users.notifyList.push(user);
+      users.addFriend(user);
     }
-    if(/notify/i.test(msg))
-      awaiting.resolve('notify-list');
+  }
+
+  match = msg.match(/^\[(\w+)\] removed from your notify list\./m);
+  if(match) {
+    const user = match[1];
+    users.notifyList = users.notifyList.filter(item => item !== user);
   }
 
   match = msg.match(/Blitz\s+Standard\s+Lightning/m);
@@ -2697,49 +2714,16 @@ function parseUserList(msg: string): any[] {
 
 /**
  * Parse the result from the server '=notify' command into a list of usernames
- * Returns null if the message doesn't look like a notify list response.
  */
-function parseNotifyList(msg: string): string[] | null {
-  const lower = msg.toLowerCase();
-  if(!lower.includes('notify'))
-    return null;
-
-  if(/notify list\s*:\s*0\s+names/i.test(msg))
-    return [];
-
-  if(/notify list is empty|no users on your notify list|you have no one on your notify list|notify list empty/.test(lower))
-    return [];
-
-  let listText = '';
-  const colonMatch = msg.match(/notify list(?:\s+is)?\s*:\s*([\s\S]*)/i);
-  if(colonMatch && colonMatch[1]) {
-    listText = colonMatch[1];
+function parseNotifyList(msg: string): string[] {
+  const users: string[] = [];
+  for(let line of msg.split('\n').slice(1)) {
+    const userStrings = line.split(/\s+/);
+    userStrings.forEach((val) => {
+      users.push(val);
+    });
   }
-  else {
-    const lines = msg.split('\n');
-    const headerIndex = lines.findIndex(line => /notify list/i.test(line));
-    if(headerIndex !== -1) {
-      listText = lines.slice(headerIndex + 1).join(' ');
-    }
-  }
-
-  if(!listText)
-    return null;
-
-  listText = listText.replace(/^-+\s*/, '').replace(/\s*-+$/, '').trim();
-
-  const ignore = new Set(['notify', 'list', 'is', 'your', 'you', 'have', 'no', 'none', 'on', 'the', 'users', 'user', 'names', 'displayed', 'there', 'are', 'currently', 'empty']);
-  const tokens = listText.replace(/[;,]/g, ' ').split(/\s+/).filter(Boolean);
-  const names = tokens.filter(token => {
-    const normalized = token.toLowerCase();
-    if(ignore.has(normalized))
-      return false;
-    if(token.length > 17)
-      return false;
-    return /^[A-Za-z()]+$/.test(token);
-  });
-
-  return names;
+  return users;
 }
 
 /** *******************************************************
@@ -2758,7 +2742,7 @@ function updateBoardStatusText() {
       const nameRatingElement = $(element).find('.name-rating');
 
       const name = nameElement.text();
-      nameElement.toggleClass('clickable-user', name && name !== 'Computer' && name !== session?.getUser() && !name.includes(' '));
+      nameElement.toggleClass('clickable-user', name && name !== 'Computer' && !name.includes(' '));
 
       nameElement.css('font-size', '');
       ratingElement.css('width', '');
@@ -3049,21 +3033,12 @@ export function updateBoard(game: Game, playMove = false, setBoard = true, anima
   if(playMove && !checkAtomicCapture(game) && settings.soundToggle && game === games.focused) {
     clearTimeout(soundTimer);
     soundTimer = setTimeout(() => {
-      if(/[+#]/.test(move?.san)) {
-        Sounds.checkSound.pause();
-        Sounds.checkSound.currentTime = 0;
-        Sounds.checkSound.play();
-      }
-      else if(move?.san.includes('x')) {
-        Sounds.captureSound.pause();
-        Sounds.captureSound.currentTime = 0;
-        Sounds.captureSound.play();
-      }
-      else {
-        Sounds.moveSound.pause();
-        Sounds.moveSound.currentTime = 0;
-        Sounds.moveSound.play();
-      }
+      if(/[+#]/.test(move?.san)) 
+        Utils.replaySound(Sounds.checkSound);
+      else if(move?.san.includes('x')) 
+        Utils.replaySound(Sounds.captureSound);
+      else 
+        Utils.replaySound(Sounds.moveSound);
     }, 50);
   }
 
@@ -4070,7 +4045,7 @@ function closeGameDialog(game: Game) {
   const button1 = ['closeGameClickHandler(event)', 'OK'];
   const button2 = ['', 'Cancel'];
   const showIcons = true;
-  Dialogs.showFixedDialog({type: headerTitle, msg: bodyText, btnFailure: button2, btnSuccess: button1, icons: showIcons});
+  Dialogs.showDialog({type: headerTitle, msg: bodyText, btnFailure: button2, btnSuccess: button1, icons: showIcons});
 }
 
 function closeGame(game: Game) {
@@ -4149,7 +4124,7 @@ function cleanupGame(game: Game) {
   game.element.find($('[title="Close"]')).css('visibility', 'visible');
   game.element.find('.title-bar-text').text('');
   game.statusElement.find('.game-id').remove();
-  $(`.board-dialog[data-game-id="${game.id}"]`).toast('hide');
+  $(`.game-dialog[data-game-id="${game.id}"]`).toast('hide');
 
   if(chat)
     chat.closeGameTab(game.id);
@@ -4900,7 +4875,7 @@ function buildInviteLink(invite: InviteCreateState): string {
 function showInviteLinkDialog(link: string, token: string) {
   const inputId = `invite-link-${token}`;
   const buttonId = `invite-copy-${token}`;
-  const dialog = Dialogs.showFixedDialog({
+  const dialog = Dialogs.showDialog({
     type: 'Invite Link',
     htmlMsg: true,
     msg: `
@@ -5147,7 +5122,7 @@ function showInviteJoinDialog(invite: InviteJoinState) {
   const summary = summaryParts.length ? ` (${summaryParts.join(', ')})` : '';
   const inviter = invite.host ? ` by ${invite.host}` : '';
 
-  const dialog = Dialogs.showFixedDialog({
+  const dialog = Dialogs.showDialog({
     type: 'Game Invite',
     htmlMsg: true,
     msg: `
@@ -5288,12 +5263,12 @@ function initInviteFromUrl() {
     const sendHandler = () => {
       sendInviteToActiveTab(invite);
       window.history.replaceState({}, document.title, window.location.pathname);
-      Dialogs.showFixedDialog({type: 'Invite Sent', msg: 'Invite sent to your active tab.', btnSuccess: ['', 'OK']});
+      Dialogs.showDialog({type: 'Invite Sent', msg: 'Invite sent to your active tab.', btnSuccess: ['', 'OK']});
     };
     const continueHandler = () => {
       handleInviteJoinFromParams(invite, true);
     };
-    Dialogs.showFixedDialog({
+    Dialogs.showDialog({
       type: 'Active Session Detected',
       msg: bodyText,
       btnFailure: [continueHandler, 'Continue here'],
@@ -5866,7 +5841,7 @@ function clearAnalysisDialog(game: Game) {
   const button1 = ['clearAnalysisClickHandler(event)', 'OK'];
   const button2 = ['', 'Cancel'];
   const showIcons = true;
-  Dialogs.showFixedDialog({type: headerTitle, msg: bodyText, btnFailure: button2, btnSuccess: button1, icons: showIcons});
+  Dialogs.showDialog({type: headerTitle, msg: bodyText, btnFailure: button2, btnSuccess: button1, icons: showIcons});
 }
 
 /** GAME PANEL TOOLBAR AND TOOL MENU FUNCTIONS **/
@@ -6050,7 +6025,7 @@ function newGameDialog(game: Game, category = 'untimed') {
       button2 = ['', 'Cancel'];
       showIcons = true;
     }
-    Dialogs.showFixedDialog({type: headerTitle, title: bodyTitle, msg: bodyText, btnFailure: button2, btnSuccess: button1, icons: showIcons});
+    Dialogs.showDialog({type: headerTitle, title: bodyTitle, msg: bodyText, btnFailure: button2, btnSuccess: button1, icons: showIcons});
   }
   else if(settings.multiboardToggle)
     newGame(true, game, category);
@@ -6175,7 +6150,7 @@ function openGamesOverwriteDialog(game: Game, fileStrings: string[]) {
         button2 = ['', 'Cancel'];
         showIcons = true;
       }
-      Dialogs.showFixedDialog({type: headerTitle, title: bodyTitle, msg: bodyText, btnFailure: button2, btnSuccess: button1, icons: showIcons});
+      Dialogs.showDialog({type: headerTitle, title: bodyTitle, msg: bodyText, btnFailure: button2, btnSuccess: button1, icons: showIcons});
     }
     else
       parseGameFiles(game, fileStrings, false);
@@ -6203,7 +6178,7 @@ async function openGameFiles(files: any): Promise<string[]> {
         reader.onerror = (e) => {
           const error = e.target?.error;
           const errorMessage = error ? `${error.name} - ${error.message}` : 'An unknown error occurred';
-          Dialogs.showFixedDialog({type: 'Failed to open game file', msg: errorMessage, btnSuccess: ['', 'OK']});
+          Dialogs.showDialog({type: 'Failed to open game file', msg: errorMessage, btnSuccess: ['', 'OK']});
           reject(error);
         };
         reader.readAsText(file);
@@ -6265,7 +6240,7 @@ async function parseGameFiles(game: Game, gameFileStrings: string[], createNewBo
                 fenCount++;
               }
               else {
-                Dialogs.showFixedDialog({type: 'Invalid FEN', msg: err, btnSuccess: ['', 'OK']});
+                Dialogs.showDialog({type: 'Invalid FEN', msg: err, btnSuccess: ['', 'OK']});
                 return;
               }
             }
@@ -6292,7 +6267,7 @@ async function parsePGNMetadata(pgnStr: string) {
     return pgn.tags;
   }
   catch(err) {
-    Dialogs.showFixedDialog({type: 'Failed to parse PGN', msg: err.message, btnSuccess: ['', 'OK']});
+    Dialogs.showDialog({type: 'Failed to parse PGN', msg: err.message, btnSuccess: ['', 'OK']});
   }
 }
 
@@ -6307,7 +6282,7 @@ async function parsePGNMoves(game: Game, pgnStr: string) {
     game.history.goto(game.history.first());
   }
   catch(err) {
-    Dialogs.showFixedDialog({type: 'Failed to parse PGN', msg: err.message, btnSuccess: ['', 'OK']});
+    Dialogs.showDialog({type: 'Failed to parse PGN', msg: err.message, btnSuccess: ['', 'OK']});
   }
 }
 
@@ -6624,8 +6599,8 @@ function savePGN(game: Game, pgn: string) {
   const wname = metatags.White;
   const bname = metatags.Black;
   let event = metatags.Event;
-  let date = metatags.Date;
-  let time = metatags.Time;
+  let date = metatags.Date || metatags.UTCDate;
+  let time = metatags.Time || metatags.UTCTime;
   if(date) {
     date = date.replace(/\./g, '-');
     const match = date.match(/^\d+(-\d+)?(-\d+)?/);
@@ -6962,7 +6937,7 @@ function setupDone(game: Game) {
 
   const err = ChessHelper.validateFEN(fen, game.category);
   if(err) {
-    Dialogs.showFixedDialog({type: 'Invalid Position', msg: err, btnSuccess: ['', 'OK']});
+    Dialogs.showDialog({type: 'Invalid Position', msg: err, btnSuccess: ['', 'OK']});
     return;
   }
 
@@ -7040,7 +7015,7 @@ $('#game-tools-properties').on('click', () => {
       updateGameFromMetatags(games.focused);
     }
     catch(err) {
-      Dialogs.showFixedDialog({type: 'Failed to update properties', msg: err.message, btnSuccess: ['', 'OK']});
+      Dialogs.showDialog({type: 'Failed to update properties', msg: err.message, btnSuccess: ['', 'OK']});
       return;
     }
   };
@@ -7051,7 +7026,7 @@ $('#game-tools-properties').on('click', () => {
       + `${games.focused.history.metatagsToString()}</textarea>`;
   const button1 = [okHandler, 'Keep Changes'];
   const button2 = ['', 'Cancel'];
-  Dialogs.showFixedDialog({type: headerTitle, msg: bodyText, btnFailure: button2, btnSuccess: button1, htmlMsg: true});
+  Dialogs.showDialog({type: headerTitle, msg: bodyText, btnFailure: button2, btnSuccess: button1, htmlMsg: true});
 });
 
 /**
@@ -7768,7 +7743,7 @@ $('#draw').on('click', () => {
         messageHandler(gameEndData);
       }
       else
-        Dialogs.showBoardDialog({type: 'Draw Offer Declined', msg: 'Computer declines the draw offer'});
+        Dialogs.showDialog({type: 'Draw Offer Declined', msg: 'Computer declines the draw offer'}, 'game');
     }
     else
       session.send('draw');

--- a/src/js/parser.ts
+++ b/src/js/parser.ts
@@ -343,6 +343,105 @@ export class Parser {
       };
     }
 
+    // offers info (seekinfo and pendinfo)
+    const index = msg.search(/^<(pt|pf|pr|s|sc|sn|sr)>/m)
+    if(index !== -1) {
+      // if plain text componenet, split into 2 messages
+      const plainText = msg.slice(0, index).trim();
+      if(plainText)
+        return [this._parse(plainText), this._parse(msg.slice(index))];
+
+      const offers = [];
+      const lines = msg.split('\n');
+      for(let line of lines) {
+        line = line.trim();
+        // parse pendinfo
+        match = line.match(/^<(pt|pf)> (\d+) w=(\S+) t=(\S+) p=((\S+)(?: \(\s*(\S+)\)(?: \[(black|white)\])? (\S+) \(\s*(\S+)\) (rated|unrated) (\S+)(?: (\d+) (\d+))?(?: Loaded from (\S+))?( \(adjourned\))?)?)/);
+        if(match) {
+          const type = match[1];
+          const subtype = match[4];
+
+          if(subtype === 'match') {
+            offers.push({
+              type: match[1],
+              id: match[2],
+              toFrom: match[3],
+              subtype: match[4],
+              asString: match[5],
+              player: (type === 'pt' ? match[6] : match[9]),
+              playerRating: (type === 'pt' ? match[7] : match[10]),
+              opponent: (type === 'pt' ? match[9] : match[6]),
+              opponentRating: (type === 'pt' ? match[10] : match[7]),
+              color: match[8],
+              ratedUnrated: match[11],
+              category: match[15] || match[12],
+              initialTime: +match[13],
+              increment: +match[14],
+              adjourned: !!match[16]
+            });
+          }
+          else {
+            offers.push({
+              type: match[1],
+              id: match[2],
+              toFrom: match[3],
+              subtype: match[4],
+              parameters: match[5]
+            });
+          }
+          continue;
+        }
+        // parse seekinfo
+        if(line === '<sc>') {
+          offers.push({ type: 'sc' });
+          continue;
+        }
+        match = line.match(/^<(s|sn)> (\d+) w=(\S+) ti=(\d+) rt=(\S+)\s+t=(\d+) i=(\d+) r=(\S+) tp=(\S+) c=(\S+) rr=(\S+) a=(\S+) f=(\S+)/);
+        if(match) {
+          offers.push({
+            type: match[1],
+            id: match[2],
+            toFrom: match[3],
+            title: titleToString[+match[4]],
+            rating: (match[5] === '0P' ? '' : match[5]),
+            initialTime: +match[6],
+            increment: +match[7],
+            ratedUnrated: match[8],
+            category: match[9],
+            color: match[10],
+            ratingRange: match[11],
+            automatic: match[12] === 't',
+            formula: match[13] === 't'
+          });
+          continue;
+        }
+        match = line.match(/^<(pr|sr)> (.+)/);
+        if(match) {
+          offers.push({
+            type: match[1],
+            ids: match[2].split(' ')
+          });
+        }
+      }
+      return {
+        offers,
+      }
+    }
+
+    match = msg.match(/^Your seeks have been removed\./m);
+    if(!match)
+      match = msg.match(/^Your seek (\d+) has been removed\./m);
+    if(match) {
+      const ids = match.length > 1 ? [match[1]] : [];
+      return {
+        offers: [{
+          type: 'sr',
+          ids: ids,
+        }],
+        raw: msg
+      };
+    }
+
     // held pieces (Crazyhouse/Bughouse)
     match = msg.match(/^<b1> game (\d+) white \[(\w*)\] black \[(\w*)\](?: <- (\w+))?/m);
     if (match != null && match.length > 3) {
@@ -475,105 +574,6 @@ export class Parser {
         messages,
         raw: msg
       }
-    }
-
-    // offers info (seekinfo and pendinfo)
-    const index = msg.search(/^<(pt|pf|pr|s|sc|sn|sr)>/m)
-    if(index !== -1) {
-      // if plain text componenet, split into 2 messages
-      const plainText = msg.slice(0, index).trim();
-      if(plainText)
-        return [this._parse(plainText), this._parse(msg.slice(index))];
-
-      const offers = [];
-      const lines = msg.split('\n');
-      for(let line of lines) {
-        line = line.trim();
-        // parse pendinfo
-        match = line.match(/^<(pt|pf)> (\d+) w=(\S+) t=(\S+) p=((\S+)(?: \(\s*(\S+)\)(?: \[(black|white)\])? (\S+) \(\s*(\S+)\) (rated|unrated) (\S+)(?: (\d+) (\d+))?(?: Loaded from (\S+))?( \(adjourned\))?)?)/);
-        if(match) {
-          const type = match[1];
-          const subtype = match[4];
-
-          if(subtype === 'match') {
-            offers.push({
-              type: match[1],
-              id: match[2],
-              toFrom: match[3],
-              subtype: match[4],
-              asString: match[5],
-              player: (type === 'pt' ? match[6] : match[9]),
-              playerRating: (type === 'pt' ? match[7] : match[10]),
-              opponent: (type === 'pt' ? match[9] : match[6]),
-              opponentRating: (type === 'pt' ? match[10] : match[7]),
-              color: match[8],
-              ratedUnrated: match[11],
-              category: match[15] || match[12],
-              initialTime: +match[13],
-              increment: +match[14],
-              adjourned: !!match[16]
-            });
-          }
-          else {
-            offers.push({
-              type: match[1],
-              id: match[2],
-              toFrom: match[3],
-              subtype: match[4],
-              parameters: match[5]
-            });
-          }
-          continue;
-        }
-        // parse seekinfo
-        if(line === '<sc>') {
-          offers.push({ type: 'sc' });
-          continue;
-        }
-        match = line.match(/^<(s|sn)> (\d+) w=(\S+) ti=(\d+) rt=(\S+)\s+t=(\d+) i=(\d+) r=(\S+) tp=(\S+) c=(\S+) rr=(\S+) a=(\S+) f=(\S+)/);
-        if(match) {
-          offers.push({
-            type: match[1],
-            id: match[2],
-            toFrom: match[3],
-            title: titleToString[+match[4]],
-            rating: (match[5] === '0P' ? '' : match[5]),
-            initialTime: +match[6],
-            increment: +match[7],
-            ratedUnrated: match[8],
-            category: match[9],
-            color: match[10],
-            ratingRange: match[11],
-            automatic: match[12] === 't',
-            formula: match[13] === 't'
-          });
-          continue;
-        }
-        match = line.match(/^<(pr|sr)> (.+)/);
-        if(match) {
-          offers.push({
-            type: match[1],
-            ids: match[2].split(' ')
-          });
-        }
-      }
-      return {
-        offers,
-      }
-    }
-
-    match = msg.match(/^Your seeks have been removed\./m);
-    if(!match)
-      match = msg.match(/^Your seek (\d+) has been removed\./m);
-    if(match) {
-      const ids = match.length > 1 ? [match[1]] : [];
-      return {
-        offers: [{
-          type: 'sr',
-          ids: ids,
-        }],
-        raw: msg
-      };
     }
 
     return { message: msg };

--- a/src/js/settings.ts
+++ b/src/js/settings.ts
@@ -38,6 +38,13 @@ export const settings = {
   evalBarToggle: true,
   // toggle for showing the best move arrow when the engine is running
   bestMoveArrowToggle: true,
+  // toggle for showing an engine's move rating icon on the board 
+  moveRatingIconToggle: true,
+  // toggle for showing the previous best move arrow (the best alternative to the move played)
+  prevBestMoveArrowToggle: false,
+  // toggle for showing any engine visuals on the board including best move arrows and move rating icon
+  engineBoardVisualsToggle: true,
+
   // name of the chess engine to use
   analyzeEngineName: isMobile() && deviceMemory < 4 ? 'Stockfish MV 2019' : 'Stockfish 17.1 Lite',
   playEngineName: isMobile() && deviceMemory < 4 ? 'Stockfish MV 2019' : 'Stockfish 17.1 Lite',

--- a/src/js/tournaments.ts
+++ b/src/js/tournaments.ts
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import { awaiting, storage } from './storage';
-import { createNotification, removeNotification, showFixedDialog } from './dialogs';
+import { createNotification, removeNotification, showDialog } from './dialogs';
 import { convertToServerDate, convertToLocalDate, parseDate, getDiffDays, getNextWeekDayDate } from './utils';
 
 /**
@@ -1338,7 +1338,7 @@ export class Tournaments {
         const button1 = [`td withdraw ${tourney.id}`, 'OK'];
         const button2 = ['', 'Cancel'];
         const showIcons = true;
-        showFixedDialog({type: headerTitle, msg: bodyText, btnFailure: button2, btnSuccess: button1, icons: showIcons, useSessionSend: true});
+        showDialog({type: headerTitle, msg: bodyText, btnFailure: button2, btnSuccess: button1, icons: showIcons, useSessionSend: true});
       });
 
       /** 'Play Game' button */

--- a/src/js/users.ts
+++ b/src/js/users.ts
@@ -5,6 +5,7 @@
 import { awaiting, storage } from './storage';
 import { createContextMenuTrigger, createContextMenu, getValue, removeWithTooltips, sortTable, scrollToTop, getTouchClickCoordinates } from './utils';
 import { showTab, setRematchUser } from './index';
+import { showDialog } from './dialogs';
 
 /** 
  * Users modal (friend list etc) and user context menu for clicking on a user's name and performing actions 
@@ -13,6 +14,7 @@ export class Users {
   private session = null;           // The current session
   private chat = null;              
   public userList: any[];           // The list of online users, from the 'who' command
+  public notifyList: any[];         // The user's notify list
   public friendList: any[] = [];
   public topPlayersList: any[];     // The list of top players from for each category, from the 'hbest' command 
   private updateUsersTimer = null;  // 1 minute timer that sends 'who' and 'hbest' commands when users modal is showing
@@ -27,7 +29,7 @@ export class Users {
 
       const target = $(event.target);
       const nameElem = target.closest('.clickable-user');
-      return nameElem.length && nameElem.text() && nameElem.text() !== this.session.getUser()
+      return nameElem.length && nameElem.text()
           && (event.type !== 'click' || !nameElem.closest('li').length);
     }, (e) => this.createUserActionsMenu(e), true, true, true);
 
@@ -43,9 +45,7 @@ export class Users {
         if(this.session?.isConnected()) {
           awaiting.set('userlist');
           this.session.send('who');
-          console.log('hello?');
           if($('#top-players-tab').hasClass('active')) {
-            console.log('hello 2');
             awaiting.set('hbest');
             this.session.send('hbest lbsxBzLSw');
           }
@@ -60,7 +60,7 @@ export class Users {
 
     $('#users-modal').on('hide.bs.modal', () => {
       clearInterval(this.updateUsersTimer);
-      $('.info-dialog').remove();
+      $('.above-modal-dialog').remove();
     });
 
     $('#add-friend').on('submit', (event) => {
@@ -114,12 +114,30 @@ export class Users {
       $(e.currentTarget).parent().css('display', ''); 
     });
 
-    $('.users-table').on('click', '.delete-user', (e) => {
+    $('.users-table').on('click', '.delete-user', (e) => {    
       const row = $(e.currentTarget).closest('tr');
       const name = row.attr('data-name');
+
       if($(e.currentTarget).closest('#friends-table').length) {
-        this.friendList = this.friendList.filter(item => item.name !== name);
-        this.saveFriends();
+        const removeFriend = () => {
+          if(this.notifyList.includes(name)) 
+            this.session.send(`-notify ${name}`);
+          
+          this.friendList = this.friendList.filter(item => item.name !== name);
+          this.saveFriends();
+          removeWithTooltips(row);
+        };
+
+        if(this.notifyList.includes(name)) {
+          const headerTitle = 'Remove Friend';
+          const bodyText = 'Remove friend from notify list?';
+          const button1 = [removeFriend, 'OK'];
+          const button2 = ['', 'Cancel'];
+          const dialog = showDialog({type: headerTitle, msg: bodyText, btnFailure: button2, btnSuccess: button1, icons: true}, 'modal');
+          return;
+        } 
+        else 
+          removeFriend();
       }
       removeWithTooltips(row);
     });
@@ -334,14 +352,19 @@ export class Users {
   /**
    * Add a friend to the friend list
    * @param name The name plus titles of the friend, e.g. Kasparov(GM)(TD)
-   * @param the friend's rating (if known)
+   * @param rating the friend's rating (if known)
    * @param updateTable If true update the friends table after adding. We might want to defer this 
    * if adding many friends at once
+   * @param save If true save friend list to localstorage after adding
+   * @returns true if friend was added, false otherwise
    */
   public addFriend(name: string, rating = '', updateTable = true, save = true) {
     name = name.trim();
     if(!name || name.length > 17 || !/^[A-Za-z()]+$/.test(name)) // Test name is a valid username
-      return;
+      return false;
+
+    if(rating == null)
+      rating = '';
 
     // Split name into name and titles
     let title = '';
@@ -354,7 +377,7 @@ export class Users {
     let friend = this.friendList.find(item => item.name.toLowerCase() === name.toLowerCase());
     if(friend) {
       // name already exists
-      return;
+      return false;
     }
 
     const user = this.userList?.find(item => item.name.toLowerCase() === name.toLowerCase());
@@ -376,6 +399,8 @@ export class Users {
 
     if(updateTable)
       this.updateUsersTable($('#friends-table'), this.friendList); // update the friends table
+
+    return true;
   }
 
   /**
@@ -401,17 +426,15 @@ export class Users {
   }
 
   /**
-   * Add users from a notify list to the friends list
+   * Add a list of names to the friends list
    */
-  public addFriendsFromNotify(names: string[]) {
-    if(!names || !names.length)
+  public addFriendList(users: any[]) {
+    if(!users || !users.length)
       return;
 
     let added = false;
-    names.forEach((name) => {
-      const before = this.friendList.length;
-      this.addFriend(name, '', false, false);
-      if(this.friendList.length !== before)
+    users.forEach((user) => {
+      if(this.addFriend(user.name, user.rating, false, false))
         added = true;
     });
 
@@ -491,20 +514,24 @@ export class Users {
     let name = nameElement.length ? nameElement.attr('data-name') : $(e.target).text();
     name = name.trim().split('(')[0]; // Remove titles from end of username
 
-    const menu = $(`<ul class="dropdown-menu noselect user-actions-menu">
-      ${!this.friendList.find(friend => friend.name.toLowerCase() === name.toLowerCase()) ? '<li><a class="dropdown-item" data-action="add-friend">Add Friend</a></li>' : ''}   
-      <li><a class="dropdown-item" data-action="message">Message</a></li>
-      <li><a class="dropdown-item" data-action="challenge">Challenge</a></li>
-      <li><a class="dropdown-item" data-action="rematch">Rematch</a></li>
-      <li><a class="dropdown-item" data-action="observe">Observe</a></li>
-      <li><a class="dropdown-item" data-action="follow">Follow</a></li>
-      <li><a class="dropdown-item" data-action="unfollow">Unfollow</a></li>
-      <li><a class="dropdown-item" data-action="finger">Finger</a></li>
-      <li><a class="dropdown-item" data-action="history">History</a></li>
-      <li><a class="dropdown-item" data-action="h2h">Head to Head</a></li>
-      <li><a class="dropdown-item" data-action="noplay">Add to 'No Play'</a></li>
-      <li><a class="dropdown-item" data-action="censor">Censor</a></li>
-    </ul>`);
+    const menu = (name.toLowerCase() === this.session.getUser().toLowerCase())
+      ? $(`<ul class="dropdown-menu noselect user-actions-menu">
+          <li><a class="dropdown-item" data-action="finger">Finger</a></li>  
+        </ul>`)
+      : $(`<ul class="dropdown-menu noselect user-actions-menu">
+        ${!this.friendList.find(friend => friend.name.toLowerCase() === name.toLowerCase()) ? '<li><a class="dropdown-item" data-action="add-friend">Add Friend</a></li>' : ''}   
+        <li><a class="dropdown-item" data-action="message">Message</a></li>
+        <li><a class="dropdown-item" data-action="challenge">Challenge</a></li>
+        <li><a class="dropdown-item" data-action="rematch">Rematch</a></li>
+        <li><a class="dropdown-item" data-action="observe">Observe</a></li>
+        <li><a class="dropdown-item" data-action="follow">Follow</a></li>
+        <li><a class="dropdown-item" data-action="unfollow">Unfollow</a></li>
+        <li><a class="dropdown-item" data-action="finger">Finger</a></li>
+        <li><a class="dropdown-item" data-action="history">History</a></li>
+        <li><a class="dropdown-item" data-action="h2h">Head to Head</a></li>
+        <li><a class="dropdown-item" data-action="noplay">Add to 'No Play'</a></li>
+        <li><a class="dropdown-item" data-action="censor">Censor</a></li>
+      </ul>`);
 
     const userActionsItemSelected = (e2) => {
       const menuItem = $(e2.target).closest('.dropdown-item');

--- a/src/js/utils.ts
+++ b/src/js/utils.ts
@@ -1070,6 +1070,15 @@ export async function getAudioDuration(audio) {
   return audio.duration;
 }
 
+/** Plays a sound. If there is a current instance playing, restarts it from the beginning */
+export function replaySound(sound: any) {
+  if(!sound.paused) {
+    sound.pause();
+    sound.currentTime = 0;
+  }
+  sound.play();
+}
+
 /**
  * An object representing a sprite animation. Contains a sprite sheet as well as the
  * properties used to control the sprite. Used by SpritePlayer class.

--- a/src/play.html
+++ b/src/play.html
@@ -29,32 +29,6 @@
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Math&family=Noto+Sans+Symbols+2&display=swap" rel="stylesheet">
 </head>
 <body>
-  <div class="status-shim"></div>
-  <svg xmlns="http://www.w3.org/2000/svg" style="display: none">
-    <symbol id="icon-info" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16">
-      <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
-      <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/>
-    </symbol>
-  </svg>
-  <div id="sign-in-alert" class="banner-alert fade" role="alert">Signing in...</div>
-  <div id="notifications" style="z-index: 2000; position: fixed; top: env(safe-area-inset-top); right: 0; width: 100%">
-    <div class="toast notification-panel" data-bs-animation="false" data-bs-autohide="false" role="status" aria-live="polite" aria-atomic="true" id="notifications-header">
-      <div class="toast-body position-relative d-flex">
-        <span class="mx-auto">Notifications</span>
-        <button type="button" class="btn-close" style="background: transparent; position: absolute; right: 6px; top: 50%; transform: translateY(-50%);" aria-label="Hide">
-          <span id="notifications-close-icon" class="fa-solid fa-chevron-down" aria-hidden="false"></span>
-        </button>
-      </div>
-    </div>
-    <div class="toast notification-panel" data-bs-animation="false" data-bs-autohide="false" role="status" aria-live="polite" aria-atomic="true" id="notifications-footer">
-      <div class="toast-body">
-        <div class="d-flex">
-          <a class="me-auto" id="notifications-clear-all" style="cursor: pointer; text-decoration: none; font-style: italic">Clear all</a>
-          <a class="ms-auto" id="notifications-show-all" style="cursor: pointer; text-decoration: none; font-style: italic">Show all >></a>
-        </div>
-      </div>
-    </div>
-  </div>
   <div class="feature3 p-0 position-relative">
     <div class="row m-0" id="main-row">
       <div class="card-group p-0">
@@ -322,16 +296,16 @@
                                 <div id="lobby" class="flex-grow-1" style="min-height: 0">
                                   <div class="d-flex flex-column h-100">
                                     <div class="center p-2 justify-content-around">
-                                      <div>
+                                      <div class="eye-toggle">
                                         <input type="checkbox" class="btn-check" id="lobby-show-computers" autocomplete="off">
                                         <label class="btn btn-default border-0" for="lobby-show-computers">
-                                          <span id="lobby-show-computers-icon" class="fa-regular fa-eye me-2" aria-hidden="false"></span>Computers
+                                          <span id="lobby-show-computers-icon" class="fa-regular fa-eye eye-toggle-icon" aria-hidden="false"></span>Computers
                                         </label>
                                       </div>
-                                      <div>
+                                      <div class="eye-toggle">
                                         <input type="checkbox" class="btn-check" id="lobby-show-unrated" autocomplete="off">
                                         <label class="btn btn-default border-0" for="lobby-show-unrated">
-                                          <span id="lobby-show-unrated-icon" class="fa-regular fa-eye me-2" aria-hidden="false"></span>Unrated
+                                          <span id="lobby-show-unrated-icon" class="fa-regular fa-eye eye-toggle-icon" aria-hidden="false"></span>Unrated
                                         </label>
                                       </div>
                                     </div>
@@ -529,14 +503,18 @@
                             <button type="button" id="add-pv" class="btn btn-engine btn-outline-secondary btn-sm p-0" title="Add Engine Line">+</button>
                           </div>
                           <div class="d-flex flex-grow-1 ms-auto align-items-center justify-content-between" style="max-width: 280px;">
-                            <input type="checkbox" class="btn-check" id="best-move-arrow-toggle" autocomplete="off">
-                            <label class="btn btn-default ms-1 py-1 px-1 border-0" style="display: block; line-height: 1; white-space: nowrap" for="best-move-arrow-toggle">
-                              <span id="best-move-arrow-toggle-icon" class="fa-regular fa-eye me-2" aria-hidden="false"></span>Best Arrow
-                            </label>
-                            <input type="checkbox" class="btn-check" id="eval-bar-toggle" autocomplete="off">
-                            <label class="btn btn-default py-1 px-1 border-0" style="display: block; line-height: 1; white-space: nowrap" for="eval-bar-toggle">
-                              <span id="eval-bar-toggle-icon" class="fa-regular fa-eye me-2" style="display: inline-block; width: 18px;" aria-hidden="false"></span>Eval Bar
-                            </label>
+                            <div class="eye-toggle">
+                              <input type="checkbox" class="btn-check" id="engine-board-visuals-toggle" autocomplete="off">
+                              <label class="btn btn-default ms-1 py-1 px-1 border-0" style="display: block; line-height: 1;" for="engine-board-visuals-toggle">
+                                <span id="engine-board-visuals-toggle-icon" class="fa-regular fa-eye eye-toggle-icon" aria-hidden="false"></span>Board Visuals
+                              </label>
+                            </div>
+                            <div class="eye-toggle">
+                              <input type="checkbox" class="btn-check" id="engine-panel-eval-bar-toggle" autocomplete="off">
+                              <label class="btn btn-default py-1 px-1 border-0" style="display: block; line-height: 1;" for="engine-panel-eval-bar-toggle">
+                                <span id="engine-panel-eval-bar-toggle-icon" class="fa-regular fa-eye eye-toggle-icon" aria-hidden="false"></span>Eval Bar
+                              </label>
+                            </div>
                             <button id="engine-settings-btn" type="button" style="line-height: 1;" class="btn btn-outline-secondary btn-transparent px-1 py-0" data-bs-toggle="tooltip" aria-haspopup="true" aria-expanded="false" title="Engine Settings" aria-label="Engine Settings">
                               <span class="fa-solid fa-gear" aria-hidden="false"></span>
                             </button>
@@ -960,14 +938,53 @@
                                 <input type="range" class="form-range me-2" style="margin-top: 0.125rem" id="engine-memory-slider" min="0" max="5" value="0">
                                 <span id="engine-memory-value" style="min-width: 9ch; white-space: nowrap;"></span>
                               </div>
+                              <hr/>
+                              <div class="row">
+                                <div class="col-12 col-md">
+                                  <div class="eye-toggle">         
+                                    <input type="checkbox" class="btn-check" id="eval-bar-toggle" autocomplete="off">
+                                    <label class="btn btn-default" for="eval-bar-toggle">
+                                      <span id="eval-bar-toggle-icon" class="fa-regular fa-eye eye-toggle-icon" aria-hidden="false"></span>Eval Bar
+                                    </label>
+                                    <div class="settings-toggle-help eye-toggle-help">Shows an eval bar next to the board.</div>
+                                  </div>
+                                </div>
+                                <div class="col-12 col-md"> 
+                                  <div class="eye-toggle">         
+                                    <input type="checkbox" class="btn-check" id="move-rating-toggle" autocomplete="off">
+                                    <label class="btn btn-default" for="move-rating-toggle">
+                                      <span id="move-rating-toggle-icon" class="fa-regular fa-eye eye-toggle-icon" aria-hidden="false"></span>Move Rating Icon
+                                    </label>
+                                    <div class="settings-toggle-help eye-toggle-help">Shows a move rating bubble next to the last played move.</div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div class="row">
+                                <div class="col-12 col-md">
+                                  <div class="eye-toggle">     
+                                    <input type="checkbox" class="btn-check form-check-input" id="best-move-arrow-toggle" autocomplete="off">
+                                    <label class="btn btn-default" for="best-move-arrow-toggle">
+                                      <span id="best-move-arrow-toggle-icon" class="fa-regular fa-eye eye-toggle-icon" aria-hidden="false"></span>Best Move Arrow
+                                    </label>
+                                    <div class="settings-toggle-help eye-toggle-help">Shows the engine's first choice move on the board.</div>
+                                  </div>
+                                </div>
+                                <div class="col-12 col-md">
+                                  <div class="eye-toggle">    
+                                    <input type="checkbox" class="btn-check" id="prev-best-move-arrow-toggle" autocomplete="off">
+                                    <label class="btn btn-default" for="prev-best-move-arrow-toggle">
+                                      <span id="prev-best-move-arrow-toggle-icon" class="fa-regular fa-eye eye-toggle-icon" aria-hidden="false"></span>Previous Best Move Arrow
+                                    </label>
+                                    <div class="settings-toggle-help eye-toggle-help">Shows the engine's first choice alternative for the last played move.</div>
+                                  </div>
+                                </div>
+                              </div>
                             </div>
-
                             <div class="tab-pane fade" id="settings-shortcuts" role="tabpanel" aria-labelledby="settings-shortcuts-tab" tabindex="0">
                               <div class="d-flex flex-column settings-shortcuts-layout">
                                 <label class="form-heading mb-1">Shortcuts:</label>
                                 <div class="d-flex settings-shortcuts-body">
-                                  <ul id="shortcuts-list" class="dropdown-menu show">
-                                  </ul>
+                                  <ul id="shortcuts-list" class="dropdown-menu show"></ul>
                                   <div id="shortcut-settings-right-col">
                                     <div id="shortcut-buttons" class="mb-3">
                                       <button type="button" id="new-shortcut" class="btn btn-outline-secondary btn-sm" title="New Shortcut">New Shortcut</button>
@@ -1266,6 +1283,32 @@
       </div>
     </div>
   </div>
+  <div class="status-shim"></div>
+  <div id="sign-in-alert" class="banner-alert fade" role="alert">Signing in...</div>
+  <div id="notifications" style="z-index: 2000; position: fixed; top: env(safe-area-inset-top); right: 0; width: 100%">
+    <div class="toast notification-panel" data-bs-animation="false" data-bs-autohide="false" role="status" aria-live="polite" aria-atomic="true" id="notifications-header">
+      <div class="toast-body position-relative d-flex">
+        <span class="mx-auto">Notifications</span>
+        <button type="button" class="btn-close" style="background: transparent; position: absolute; right: 6px; top: 50%; transform: translateY(-50%);" aria-label="Hide">
+          <span id="notifications-close-icon" class="fa-solid fa-chevron-down" aria-hidden="false"></span>
+        </button>
+      </div>
+    </div>
+    <div class="toast notification-panel" data-bs-animation="false" data-bs-autohide="false" role="status" aria-live="polite" aria-atomic="true" id="notifications-footer">
+      <div class="toast-body">
+        <div class="d-flex">
+          <a class="me-auto" id="notifications-clear-all" style="cursor: pointer; text-decoration: none; font-style: italic">Clear all</a>
+          <a class="ms-auto" id="notifications-show-all" style="cursor: pointer; text-decoration: none; font-style: italic">Show all >></a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <svg xmlns="http://www.w3.org/2000/svg" style="display: none">
+    <symbol id="icon-info" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16">
+      <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
+      <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/>
+    </symbol>
+  </svg>
   <script src="https://code.jquery.com/jquery-3.7.1.slim.min.js" integrity="sha384-5AkRS45j4ukf+JbWAfHL8P4onPA9p0KwwP7pUdjSQA3ss9edbJUJc/XcYAiheSSz" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.min.js" integrity="sha384-G/EV+4j2dNv+tEPo3++6LCgdCROaejBqfUeNjuKAiuXbjrxilcCdDz6ZAVfHWe1Y" crossorigin="anonymous"></script>

--- a/src/play.html
+++ b/src/play.html
@@ -32,7 +32,8 @@
   <div class="feature3 p-0 position-relative">
     <div class="row m-0" id="main-row">
       <div class="card-group p-0">
-        <div id="left-col" class="main-col col-sm-12 col-md-3 col-lg-3 col-xl-3" style="min-width: 340px">
+        <div id="left-col" class="main-col col-sm-12 col-md-3 col-lg-3 col-xl-3 position-relative" style="min-width: 340px">
+          <div class="toast-container dialog-container"></div>
           <div class="card bg-transparent" id="left-card">
             <div class="card-header top-panel d-flex" id="left-panel-header" style="visibility: hidden">
               <div id="navigation-toolbar" class="btn-toolbar m-auto">
@@ -565,9 +566,7 @@
           </div>
         </div>
         <div id="mid-col" class="main-col col-sm-12 col-md-auto position-relative align-self-center">
-          <div class="toast-container h-100 w-100" style="z-index: 100;">
-            <div id="game-requests" aria-live="polite" aria-atomic="true"></div>
-          </div>
+          <div class="toast-container dialog-container"></div>
           <div id="main-board-area">
             <div class="card game-card bg-transparent">
               <div class="card-header title-bar">
@@ -783,7 +782,7 @@
                                     <label class="form-check-label" for="highlights-toggle"><span id="highlights-toggle-icon" class="fa fa-arrows-spin dropdown-icon" aria-hidden="false"></span>Board Highlights
                                       <svg class="ms-1 info-icon settings-info-icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Board Highlights" data-description="Shows board graphics such as highlights and move indicators." role="button" aria-label="Board Highlights help"><use href="#icon-info"/></svg>
                                     </label>
-                                    <div class="settings-toggle-help">Shows arrows, highlights, and other board graphics.</div>
+                                    <div class="settings-toggle-help">Shows move highlights, and other board graphics.</div>
                                   </div>
                                 </div>
                                 <div class="col"></div>
@@ -955,7 +954,7 @@
                                     <label class="btn btn-default" for="move-rating-toggle">
                                       <span id="move-rating-toggle-icon" class="fa-regular fa-eye eye-toggle-icon" aria-hidden="false"></span>Move Rating Icon
                                     </label>
-                                    <div class="settings-toggle-help eye-toggle-help">Shows a move rating bubble next to the last played move.</div>
+                                    <div class="settings-toggle-help eye-toggle-help">Shows a move rating icon in the corner of the square for the last played move.</div>
                                   </div>
                                 </div>
                               </div>
@@ -966,7 +965,7 @@
                                     <label class="btn btn-default" for="best-move-arrow-toggle">
                                       <span id="best-move-arrow-toggle-icon" class="fa-regular fa-eye eye-toggle-icon" aria-hidden="false"></span>Best Move Arrow
                                     </label>
-                                    <div class="settings-toggle-help eye-toggle-help">Shows the engine's first choice move on the board.</div>
+                                    <div class="settings-toggle-help eye-toggle-help">Highlights the engine's first choice move on the board.</div>
                                   </div>
                                 </div>
                                 <div class="col-12 col-md">
@@ -975,7 +974,7 @@
                                     <label class="btn btn-default" for="prev-best-move-arrow-toggle">
                                       <span id="prev-best-move-arrow-toggle-icon" class="fa-regular fa-eye eye-toggle-icon" aria-hidden="false"></span>Previous Best Move Arrow
                                     </label>
-                                    <div class="settings-toggle-help eye-toggle-help">Shows the engine's first choice alternative for the last played move.</div>
+                                    <div class="settings-toggle-help eye-toggle-help">Shows the engine's first choice alternative to the last played move.</div>
                                   </div>
                                 </div>
                               </div>
@@ -1152,7 +1151,8 @@
             </div>
             <div id="inner-right-panels">
               <div id="secondary-board-area" class="pt-1 ps-lg-2 pe-lg-1"></div>
-              <div id="collapse-chat" class="collapse show collapse-init">
+              <div id="collapse-chat" class="collapse show collapse-init position-relative">
+                <div class="toast-container dialog-container"></div>
                 <div id="chat-panel" class="d-flex flex-column position-relative">
                   <div class="card-body d-flex flex-column flex-grow-1" style="min-height: 0">
                     <div class="d-flex">
@@ -1283,6 +1283,7 @@
       </div>
     </div>
   </div>
+  <div class="toast-container" id="fixed-dialog-container"></div>
   <div class="status-shim"></div>
   <div id="sign-in-alert" class="banner-alert fade" role="alert">Signing in...</div>
   <div id="notifications" style="z-index: 2000; position: fixed; top: env(safe-area-inset-top); right: 0; width: 100%">


### PR DESCRIPTION
Show move rating icons on the board when analyzing.
Optional 'Previous best move arrow', which shows the engine's best alternative to the move played
Move game related dialogs, e.g.. draw, abort, takeback, so they are displayed near the board but not on top of it. 
Misc bug fixes.  