### PR TITLE
Improve training bot controls

### DIFF
--- a/src/assets/css/application.css
+++ b/src/assets/css/application.css
@@ -216,6 +216,9 @@ html, body {
   #left-panel-bottom:not(.analyzing) {
     --content-height: 5rem;
   }
+  #left-panel-bottom.puzzlebot-active:not(.analyzing) {
+    --content-height: 7rem;
+  }
   #left-panel-bottom:not(.analyzing) #status-panel {
     --padding-y: 0px;
   }
@@ -260,6 +263,10 @@ html, body {
 }
 .game-status .game-id {
   font-weight: normal;
+}
+.puzzlebot-objective,
+.puzzlebot-feedback {
+  white-space: pre-line;
 }
 .game-watchers {
   white-space: pre-wrap;

--- a/src/assets/css/application.css
+++ b/src/assets/css/application.css
@@ -53,6 +53,13 @@ html, body {
   align-items: center;
   gap: 0.625rem;
 }
+#endgamebot-game-buttons {
+  gap: 0.375rem;
+}
+#endgamebot-new {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
 
 #chat-tabContent .tab-pane {
   max-height: 100%;
@@ -216,7 +223,7 @@ html, body {
   #left-panel-bottom:not(.analyzing) {
     --content-height: 5rem;
   }
-  #left-panel-bottom.puzzlebot-active:not(.analyzing) {
+  #left-panel-bottom.trainingbot-active:not(.analyzing) {
     --content-height: 7rem;
   }
   #left-panel-bottom:not(.analyzing) #status-panel {
@@ -264,8 +271,8 @@ html, body {
 .game-status .game-id {
   font-weight: normal;
 }
-.puzzlebot-objective,
-.puzzlebot-feedback {
+.trainingbot-objective,
+.trainingbot-feedback {
   white-space: pre-line;
 }
 .game-watchers {

--- a/src/assets/css/application.css
+++ b/src/assets/css/application.css
@@ -53,14 +53,6 @@ html, body {
   align-items: center;
   gap: 0.625rem;
 }
-#endgamebot-game-buttons {
-  gap: 0.375rem;
-}
-#endgamebot-new {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
-
 #chat-tabContent .tab-pane {
   max-height: 100%;
   min-height: 100%;

--- a/src/js/endgamebot.ts
+++ b/src/js/endgamebot.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 Free Chess Club.
+// Use of this source code is governed by a GPL-style
+// license that can be found in the LICENSE file.
+
+import { TrainingBotState } from './trainingbot';
+
+const COMPLETION_MESSAGE = /Thank you for playing endgamebot\./i;
+const COMMAND_PROMPT = /\btype\s+"tell endgamebot\b/i;
+const FORCE_INSTRUCTIONS = /\s*You have to find the best moves, disable with "tell endgamebot force"\s*$/i;
+const INTRO_INSTRUCTIONS = /^Hello from endgamebot\.\s*"tell endgamebot hint"\s+if you want a hint or\s+"back"\s+if you want to make a different move\s*/i;
+const SUBOPTIMAL_MOVE_MESSAGE = /\bYou have a better move\b/i;
+
+function normalizeMessage(message: string) {
+  return message?.trim()
+    .replace(INTRO_INSTRUCTIONS, '')
+    .replace(FORCE_INSTRUCTIONS, '');
+}
+
+export class EndgameBotState extends TrainingBotState {
+  readonly kind = 'endgame' as const;
+
+  constructor(playCommand = 'play -f kpk', objectiveMessages: string[] = []) {
+    super(playCommand, objectiveMessages
+      .map(normalizeMessage)
+      .filter(message => message && !COMMAND_PROMPT.test(message)));
+  }
+
+  finish() {
+    super.finish();
+    this.feedbackPending = false;
+  }
+
+  recordMessage(message: string) {
+    const normalized = normalizeMessage(message);
+    if(!normalized || COMMAND_PROMPT.test(normalized))
+      return;
+
+    const completed = COMPLETION_MESSAGE.test(normalized);
+    const suboptimalMove = SUBOPTIMAL_MOVE_MESSAGE.test(normalized);
+    if(completed || this.feedbackPending)
+      this.feedbackMessages = [];
+
+    if(suboptimalMove)
+      this.wrongMove = true;
+
+    const messages = this.feedbackPending || completed || this.interactionStarted
+      ? this.feedbackMessages
+      : this.objectiveMessages;
+    if(messages[messages.length - 1] !== normalized)
+      messages.push(normalized);
+
+    if(this.feedbackPending)
+      this.feedbackPending = false;
+    if(completed)
+      this.finish();
+  }
+
+  protected fallbackObjective() {
+    return 'Endgame Training';
+  }
+}

--- a/src/js/game.ts
+++ b/src/js/game.ts
@@ -109,6 +109,7 @@ export class Game extends GameData {
   endgameBotEnded = false;             // whether the current EndgameBot position has ended
   puzzleBot = false;                   // whether this board was opened by PuzzleBot
   puzzleBotEnded = false;              // whether the current PuzzleBot puzzle has ended
+  puzzleBotWrongMove = false;          // whether PuzzleBot rejected a move in the current puzzle
   puzzleBotCommand = 'getmate';        // command used to load this PuzzleBot puzzle type
   setupBoard = false;                  // in setup-board mode or not
   commitingMovelist = false;           // Used when entering examine mode and using 'commit' to submit a move list

--- a/src/js/game.ts
+++ b/src/js/game.ts
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a GPL-style
 // license that can be found in the LICENSE file.
 
+import { PuzzleBotState } from './puzzlebot';
+
 export const Role = {
   ISOLATED_POS: -3,         // isolated position, such as for "ref 3" or the "sposition" command
   OBS_EXAMINED: -2,         // I am observing game being examined
@@ -107,10 +109,7 @@ export class Game extends GameData {
   preserved = false;                   // if true, prevents a game/board from being overwritten
   endgameBot = false;                  // whether this board was opened by EndgameBot
   endgameBotEnded = false;             // whether the current EndgameBot position has ended
-  puzzleBot = false;                   // whether this board was opened by PuzzleBot
-  puzzleBotEnded = false;              // whether the current PuzzleBot puzzle has ended
-  puzzleBotWrongMove = false;          // whether PuzzleBot rejected a move in the current puzzle
-  puzzleBotCommand = 'getmate';        // command used to load this PuzzleBot puzzle type
+  puzzleBot: PuzzleBotState = null;    // state for a board opened by PuzzleBot
   setupBoard = false;                  // in setup-board mode or not
   commitingMovelist = false;           // Used when entering examine mode and using 'commit' to submit a move list
   movelistRequested = 0;               // Used to keep track of move list requests

--- a/src/js/game.ts
+++ b/src/js/game.ts
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a GPL-style
 // license that can be found in the LICENSE file.
 
-import { PuzzleBotState } from './puzzlebot';
+import { TrainingBotState } from './trainingbot';
 
 export const Role = {
   ISOLATED_POS: -3,         // isolated position, such as for "ref 3" or the "sposition" command
@@ -107,9 +107,7 @@ export class Game extends GameData {
   partnerGameId: number = null;        // bughouse partner's game id
   newVariationMode = NewVariationMode.ASK;
   preserved = false;                   // if true, prevents a game/board from being overwritten
-  endgameBot = false;                  // whether this board was opened by EndgameBot
-  endgameBotEnded = false;             // whether the current EndgameBot position has ended
-  puzzleBot: PuzzleBotState = null;    // state for a board opened by PuzzleBot
+  trainingBot: TrainingBotState = null; // state for a board opened by a training bot
   setupBoard = false;                  // in setup-board mode or not
   commitingMovelist = false;           // Used when entering examine mode and using 'commit' to submit a move list
   movelistRequested = 0;               // Used to keep track of move list requests

--- a/src/js/game.ts
+++ b/src/js/game.ts
@@ -109,6 +109,7 @@ export class Game extends GameData {
   endgameBotEnded = false;             // whether the current EndgameBot position has ended
   puzzleBot = false;                   // whether this board was opened by PuzzleBot
   puzzleBotEnded = false;              // whether the current PuzzleBot puzzle has ended
+  puzzleBotCommand = 'getmate';        // command used to load this PuzzleBot puzzle type
   setupBoard = false;                  // in setup-board mode or not
   commitingMovelist = false;           // Used when entering examine mode and using 'commit' to submit a move list
   movelistRequested = 0;               // Used to keep track of move list requests

--- a/src/js/game.ts
+++ b/src/js/game.ts
@@ -105,6 +105,10 @@ export class Game extends GameData {
   partnerGameId: number = null;        // bughouse partner's game id
   newVariationMode = NewVariationMode.ASK;
   preserved = false;                   // if true, prevents a game/board from being overwritten
+  endgameBot = false;                  // whether this board was opened by EndgameBot
+  endgameBotEnded = false;             // whether the current EndgameBot position has ended
+  puzzleBot = false;                   // whether this board was opened by PuzzleBot
+  puzzleBotEnded = false;              // whether the current PuzzleBot puzzle has ended
   setupBoard = false;                  // in setup-board mode or not
   commitingMovelist = false;           // Used when entering examine mode and using 'commit' to submit a move list
   movelistRequested = 0;               // Used to keep track of move list requests

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -180,7 +180,11 @@ let followedTarget: string | null = null;
 let endgameBotRequestPending = false;
 let endgameBotRequestTimer: ReturnType<typeof setTimeout> | null = null;
 let puzzleBotRequestPending = false;
+let puzzleBotRequestCommand = 'getmate';
 let puzzleBotRequestTimer: ReturnType<typeof setTimeout> | null = null;
+let botResponseTarget: string | null = null;
+let activeBotResponsePopover: string | null = null;
+let botResponsePopoverTimer: ReturnType<typeof setTimeout> | null = null;
 
 /**
  * Used to call session.send() from inline JS.
@@ -1292,6 +1296,8 @@ function messageHandler(data: any) {
       }
       break;
     case MessageType.ChannelTell:
+      handlePuzzleBotMessage(data);
+      handleEndgameBotMessage(data);
       chat.newMessage(data.channel, data);
       break;
     case MessageType.PrivateTell:
@@ -1457,6 +1463,7 @@ function gameStart(game: Game) {
   if(game.isExamining() && puzzleBotRequestPending) {
     game.puzzleBot = true;
     game.puzzleBotEnded = false;
+    game.puzzleBotCommand = puzzleBotRequestCommand;
     clearPuzzleBotRequest();
   }
   else if(game.isExamining() && endgameBotRequestPending) {
@@ -2952,6 +2959,9 @@ function handleMiscMessage(data: any) {
 export function cleanup() {
   chat?.cleanup();
   tournaments?.cleanup();
+  clearPuzzleBotRequest();
+  clearEndgameBotRequest();
+  clearBotResponsePopover();
   awaiting.clearAll();
   setFollowedTarget(null);
   partnerGameId = null;
@@ -4231,7 +4241,7 @@ function initGameControls(game: Game) {
   else if(game.puzzleBot && game.isExamining()) {
     Utils.hideWithPoppers($('#playing-game-buttons'));
     Utils.hideWithPoppers($('#viewing-game-buttons'));
-    $('#puzzlebot-hint, #puzzlebot-solve').prop('disabled', game.puzzleBotEnded);
+    updatePuzzleBotControls(game);
     $('#puzzlebot-game-buttons').show();
   }
   else if(game.isPlaying()) {
@@ -4395,6 +4405,7 @@ function cleanupGame(game: Game) {
   game.endgameBotEnded = false;
   game.puzzleBot = false;
   game.puzzleBotEnded = false;
+  game.puzzleBotCommand = 'getmate';
 
   if(game === games.focused) {
     hideHeaderFooterButton($('#stop-observing'));
@@ -5882,15 +5893,23 @@ function getGame(min: number, sec: number) {
     $('#opponent-player-name').attr('placeholder', 'Anyone');
 };
 
-$('#puzzlebot').on('click', () => {
-  sendPuzzleBotCommand('getmate', true);
+$('#puzzlebot').on('click', function() {
+  sendPuzzleBotCommand($(this).data('puzzlebot-command') || 'getmate', true);
+});
+
+$('#puzzlebot-types').on('click', '[data-puzzlebot-command]', function() {
+  const command = $(this).data('puzzlebot-command');
+  $('#puzzlebot').text($(this).text()).data('puzzlebot-command', command);
+  sendPuzzleBotCommand(command, true);
 });
 
 $('#puzzlebot-hint').on('click', () => {
+  expectBotResponse('#puzzlebot-hint');
   sendPuzzleBotCommand('hint');
 });
 
 $('#puzzlebot-solve').on('click', () => {
+  expectBotResponse('#puzzlebot-solve');
   setPuzzleBotEnded(games.focused);
   sendPuzzleBotCommand('solve');
 });
@@ -5900,13 +5919,12 @@ $('#puzzlebot-next').on('click', () => {
   if(game?.puzzleBot && game.isExamining())
     session.send('unex');
 
-  // PuzzleBot's sequential next command is restricted to registered users.
-  // Guests still get a useful Next Puzzle button by loading another random mate.
-  sendPuzzleBotCommand(session.isRegistered() ? 'next' : 'getmate', true);
+  sendPuzzleBotCommand(game?.puzzleBotCommand || 'getmate', true);
 });
 
 $('#puzzlebot-stop').on('click', () => {
   clearPuzzleBotRequest();
+  clearBotResponsePopover();
   sendPuzzleBotCommand('stop');
   const game = games.focused;
   if(game?.puzzleBot && game.isExamining())
@@ -5914,16 +5932,21 @@ $('#puzzlebot-stop').on('click', () => {
 });
 
 function sendPuzzleBotCommand(command: string, loadsPuzzle = false) {
-  if(loadsPuzzle) {
-    clearEndgameBotRequest();
-    puzzleBotRequestPending = true;
-    if(puzzleBotRequestTimer)
-      clearTimeout(puzzleBotRequestTimer);
-    puzzleBotRequestTimer = setTimeout(clearPuzzleBotRequest, 10000);
-  }
+  if(loadsPuzzle)
+    beginPuzzleBotRequest(command);
 
   session.send(`t puzzlebot ${command}`);
   showTab($('#pills-game-tab'));
+}
+
+function beginPuzzleBotRequest(command: string) {
+  clearEndgameBotRequest();
+  clearBotResponsePopover();
+  puzzleBotRequestPending = true;
+  puzzleBotRequestCommand = command;
+  if(puzzleBotRequestTimer)
+    clearTimeout(puzzleBotRequestTimer);
+  puzzleBotRequestTimer = setTimeout(clearPuzzleBotRequest, 10000);
 }
 
 function clearPuzzleBotRequest() {
@@ -5933,18 +5956,27 @@ function clearPuzzleBotRequest() {
   puzzleBotRequestTimer = null;
 }
 
-function setPuzzleBotEnded(game: Game) {
+function setPuzzleBotEnded(game: Game, ended = true) {
   if(!game?.puzzleBot)
     return;
 
-  game.puzzleBotEnded = true;
+  game.puzzleBotEnded = ended;
   if(game === games.focused)
-    $('#puzzlebot-hint, #puzzlebot-solve').prop('disabled', true);
+    updatePuzzleBotControls(game);
+}
+
+function updatePuzzleBotControls(game: Game) {
+  $('#puzzlebot-hint, #puzzlebot-solve').prop('disabled', game.puzzleBotEnded);
+  $('#puzzlebot-next')
+    .toggleClass('btn-success', game.puzzleBotEnded)
+    .toggleClass('btn-outline-secondary', !game.puzzleBotEnded);
 }
 
 function handlePuzzleBotMessage(data: any) {
   if(data.user?.toLowerCase() !== 'puzzlebot')
     return;
+
+  showExpectedBotResponse(data.message);
 
   if(!/You solved problem number/i.test(data.message || ''))
     return;
@@ -5962,15 +5994,18 @@ $('#endgamebot').on('click', '[data-endgamebot-pieceset]', function() {
 });
 
 $('#endgamebot-back').on('click', () => {
+  clearBotResponsePopover();
   setEndgameBotEnded(games.focused, false);
   sendEndgameBotCommand('back');
 });
 
 $('#endgamebot-hint').on('click', () => {
+  expectBotResponse('#endgamebot-hint');
   sendEndgameBotCommand('hint');
 });
 
 $('#endgamebot-move').on('click', () => {
+  expectBotResponse('#endgamebot-move');
   sendEndgameBotCommand('move');
 });
 
@@ -5980,6 +6015,7 @@ $('#endgamebot-force').on('click', () => {
 
 $('#endgamebot-stop').on('click', () => {
   clearEndgameBotRequest();
+  clearBotResponsePopover();
   sendEndgameBotCommand('stop');
   const game = games.focused;
   if(game?.endgameBot && game.isExamining())
@@ -5987,16 +6023,20 @@ $('#endgamebot-stop').on('click', () => {
 });
 
 function sendEndgameBotCommand(command: string, loadsEndgame = false) {
-  if(loadsEndgame) {
-    clearPuzzleBotRequest();
-    endgameBotRequestPending = true;
-    if(endgameBotRequestTimer)
-      clearTimeout(endgameBotRequestTimer);
-    endgameBotRequestTimer = setTimeout(clearEndgameBotRequest, 10000);
-  }
+  if(loadsEndgame)
+    beginEndgameBotRequest();
 
   session.send(`t endgamebot ${command}`);
   showTab($('#pills-game-tab'));
+}
+
+function beginEndgameBotRequest() {
+  clearPuzzleBotRequest();
+  clearBotResponsePopover();
+  endgameBotRequestPending = true;
+  if(endgameBotRequestTimer)
+    clearTimeout(endgameBotRequestTimer);
+  endgameBotRequestTimer = setTimeout(clearEndgameBotRequest, 10000);
 }
 
 function clearEndgameBotRequest() {
@@ -6019,6 +6059,8 @@ function handleEndgameBotMessage(data: any) {
   if(data.user?.toLowerCase() !== 'endgamebot')
     return;
 
+  showExpectedBotResponse(data.message);
+
   if(!/Thank you for playing endgamebot\./i.test(data.message || ''))
     return;
 
@@ -6028,6 +6070,61 @@ function handleEndgameBotMessage(data: any) {
       return;
     }
   }
+}
+
+function expectBotResponse(target: string) {
+  clearBotResponsePopover();
+  botResponseTarget = target;
+}
+
+function showExpectedBotResponse(message: string) {
+  if(!botResponseTarget || !message)
+    return;
+
+  const target = botResponseTarget;
+  botResponseTarget = null;
+  const button = $(target);
+  button.tooltip('hide');
+  button.popover({
+    content: message,
+    container: 'body',
+    placement: 'top',
+    trigger: 'manual'
+  });
+  button.popover('show');
+  activeBotResponsePopover = target;
+  botResponsePopoverTimer = setTimeout(clearBotResponsePopover, 10000);
+}
+
+function clearBotResponsePopover() {
+  botResponseTarget = null;
+  if(botResponsePopoverTimer)
+    clearTimeout(botResponsePopoverTimer);
+  botResponsePopoverTimer = null;
+  if(activeBotResponsePopover)
+    $(activeBotResponsePopover).popover('dispose');
+  activeBotResponsePopover = null;
+}
+
+function trackTrainingBotCommand(command: string) {
+  const match = command.match(/^\s*(?:t|te|tel|tell)\s+(puzzlebot|endgamebot)\s+(.+)$/i);
+  if(!match)
+    return;
+
+  const bot = match[1].toLowerCase();
+  const botCommand = match[2].trim().toLowerCase();
+  if(bot === 'puzzlebot') {
+    const loadCommand = getPuzzleBotLoadCommand(botCommand);
+    if(loadCommand)
+      beginPuzzleBotRequest(loadCommand);
+  }
+  else if(/^play(?:\s|$)/i.test(botCommand))
+    beginEndgameBotRequest();
+}
+
+function getPuzzleBotLoadCommand(command: string) {
+  const match = command.match(/^(gm|getmate|gt|gettactics|gs|getstudy)(?:[1-4])?(?:\s+\d+)?$/i);
+  return match ? command.split(/\s+/, 1)[0] : null;
 }
 
 /** LOBBY PANE FUNCTIONS **/
@@ -9674,6 +9771,8 @@ $('#input-form').on('submit', (event) => {
   }
   else
     text = val;
+
+  trackTrainingBotCommand(text);
 
   // Check if input is a chat command, and if so do processing on the message before sending
   let chatCmd: string;

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -1463,6 +1463,7 @@ function gameStart(game: Game) {
   if(game.isExamining() && puzzleBotRequestPending) {
     game.puzzleBot = true;
     game.puzzleBotEnded = false;
+    game.puzzleBotWrongMove = false;
     game.puzzleBotCommand = puzzleBotRequestCommand;
     clearPuzzleBotRequest();
   }
@@ -3508,6 +3509,11 @@ export function movePiece(source: any, target: any, metadata: any, pieceRole?: s
     sendMove(move);
 
   if(game.isExamining()) {
+    if(game.puzzleBot && game.puzzleBotWrongMove) {
+      game.puzzleBotWrongMove = false;
+      updatePuzzleBotControls(game);
+    }
+
     let nextMoveMatches = false;
     if(nextMove
         && ((!move.from && !nextMove.from && move.piece === nextMove.piece) || move.from === nextMove.from)
@@ -4405,6 +4411,7 @@ function cleanupGame(game: Game) {
   game.endgameBotEnded = false;
   game.puzzleBot = false;
   game.puzzleBotEnded = false;
+  game.puzzleBotWrongMove = false;
   game.puzzleBotCommand = 'getmate';
 
   if(game === games.focused) {
@@ -5911,14 +5918,14 @@ function getGame(min: number, sec: number) {
     $('#opponent-player-name').attr('placeholder', 'Anyone');
 };
 
-$('#puzzlebot').on('click', function() {
-  sendPuzzleBotCommand($(this).data('puzzlebot-command') || 'getmate', true);
-});
-
 $('#puzzlebot-types').on('click', '[data-puzzlebot-command]', function() {
   const command = $(this).data('puzzlebot-command');
-  $('#puzzlebot').text($(this).text()).data('puzzlebot-command', command);
-  sendPuzzleBotCommand(command, true);
+  puzzleBotRequestCommand = command;
+  const game = games.focused;
+  if(game?.puzzleBot && game.isExamining())
+    game.puzzleBotCommand = command;
+  else
+    sendPuzzleBotCommand(command, true);
 });
 
 $('#puzzlebot-hint').on('click', () => {
@@ -5979,12 +5986,19 @@ function setPuzzleBotEnded(game: Game, ended = true) {
     return;
 
   game.puzzleBotEnded = ended;
+  if(ended)
+    game.puzzleBotWrongMove = false;
   if(game === games.focused)
     updatePuzzleBotControls(game);
 }
 
 function updatePuzzleBotControls(game: Game) {
-  $('#puzzlebot-hint, #puzzlebot-solve').prop('disabled', game.puzzleBotEnded);
+  const wrongMove = game.puzzleBotWrongMove && !game.puzzleBotEnded;
+  $('#puzzlebot-hint')
+    .prop('disabled', game.puzzleBotEnded)
+    .toggleClass('btn-warning', wrongMove)
+    .toggleClass('btn-outline-secondary', !wrongMove);
+  $('#puzzlebot-solve').prop('disabled', game.puzzleBotEnded);
   $('#puzzlebot-next')
     .toggleClass('btn-success', game.puzzleBotEnded)
     .toggleClass('btn-outline-secondary', !game.puzzleBotEnded);
@@ -5995,6 +6009,17 @@ function handlePuzzleBotMessage(data: any) {
     return;
 
   showExpectedBotResponse(data.message);
+
+  if(/There is a better move\./i.test(data.message || '')) {
+    for(const game of games) {
+      if(game.puzzleBot) {
+        game.puzzleBotWrongMove = true;
+        if(game === games.focused)
+          updatePuzzleBotControls(game);
+        return;
+      }
+    }
+  }
 
   if(!/You solved problem number/i.test(data.message || ''))
     return;
@@ -6102,15 +6127,22 @@ function showExpectedBotResponse(message: string) {
   const target = botResponseTarget;
   botResponseTarget = null;
   const button = $(target);
-  button.tooltip('hide');
+  button.tooltip('dispose');
   button.popover({
     content: message,
     container: 'body',
     placement: 'top',
+    title: '',
     trigger: 'manual'
   });
   button.popover('show');
   activeBotResponsePopover = target;
+  $('body').on('click.hide-bot-response', (e) => {
+    if(!button.is(e.target)
+        && button.has(e.target).length === 0
+        && !$(e.target).closest('.popover').length)
+      clearBotResponsePopover();
+  });
   botResponsePopoverTimer = setTimeout(clearBotResponsePopover, 10000);
 }
 
@@ -6119,8 +6151,12 @@ function clearBotResponsePopover() {
   if(botResponsePopoverTimer)
     clearTimeout(botResponsePopoverTimer);
   botResponsePopoverTimer = null;
-  if(activeBotResponsePopover)
-    $(activeBotResponsePopover).popover('dispose');
+  $('body').off('click.hide-bot-response');
+  if(activeBotResponsePopover) {
+    const button = $(activeBotResponsePopover);
+    button.popover('dispose');
+    Utils.createTooltip(button);
+  }
   activeBotResponsePopover = null;
 }
 

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -23,6 +23,7 @@ import { Engine, EvalEngine, MaiaEngine } from './engine';
 import { Game, GameData, Role, NewVariationMode, games } from './game';
 import { History, HEntry } from './history';
 import { GetMessageType, MessageType, session, createSession } from './session';
+import { PuzzleBotState } from './puzzlebot';
 import * as Sounds from './sounds';
 import { storage, CredentialStorage, awaiting } from './storage';
 import { settings } from './settings';
@@ -180,8 +181,9 @@ let endgameBotRequestTimer: ReturnType<typeof setTimeout> | null = null;
 let puzzleBotRequestPending = false;
 let puzzleBotRequestCommand = 'getmate';
 let puzzleBotRequestTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingPuzzleBotMessages: string[] = [];
 let botResponseTarget: string | null = null;
-let activeBotResponsePopover: string | null = null;
+let activeBotResponsePopover: JQuery<HTMLElement> | null = null;
 let botResponsePopoverTimer: ReturnType<typeof setTimeout> | null = null;
 
 /**
@@ -1296,14 +1298,16 @@ function messageHandler(data: any) {
       }
       break;
     case MessageType.ChannelTell:
-      handlePuzzleBotMessage(data);
+      if(handlePuzzleBotMessage(data))
+        break;
       handleEndgameBotMessage(data);
       chat.newMessage(data.channel, data);
       break;
     case MessageType.PrivateTell:
       if(handleInviteTell(data))
         return;
-      handlePuzzleBotMessage(data);
+      if(handlePuzzleBotMessage(data))
+        break;
       handleEndgameBotMessage(data);
       chat.newMessage(data.user, data);
       break;
@@ -1461,10 +1465,7 @@ function gameStart(game: Game) {
     $('#exit-subvariation').hide();
 
   if(game.isExamining() && puzzleBotRequestPending) {
-    game.puzzleBot = true;
-    game.puzzleBotEnded = false;
-    game.puzzleBotWrongMove = false;
-    game.puzzleBotCommand = puzzleBotRequestCommand;
+    game.puzzleBot = new PuzzleBotState(puzzleBotRequestCommand, pendingPuzzleBotMessages);
     clearPuzzleBotRequest();
   }
   else if(game.isExamining() && endgameBotRequestPending) {
@@ -1620,7 +1621,7 @@ function gameStart(game: Game) {
   if(chat)
     chat.closeUnusedPrivateTabs();
 
-  openAssociatedChatTab(game, game.puzzleBot || game.endgameBot, false);
+  openAssociatedChatTab(game, game.endgameBot, false);
 
   if(game.isPlaying() || game.isObserving()) {
     // Adjust settings for game category (variant)
@@ -2080,7 +2081,7 @@ function handleMiscMessage(data: any) {
         }
       }
       game.statusElement.find('.game-watchers').html(req);
-      game.statusElement.find('.game-watchers').toggle(!!req);
+      game.statusElement.find('.game-watchers').toggle(!!req && !game.puzzleBot);
       return;
     }
     chat.newMessage('console', data);
@@ -3509,9 +3510,10 @@ export function movePiece(source: any, target: any, metadata: any, pieceRole?: s
     sendMove(move);
 
   if(game.isExamining()) {
-    if(game.puzzleBot && game.puzzleBotWrongMove) {
-      game.puzzleBotWrongMove = false;
+    if(game.puzzleBot) {
+      game.puzzleBot.submitMove();
       updatePuzzleBotControls(game);
+      updatePuzzleBotStatus(game);
     }
 
     let nextMoveMatches = false;
@@ -4237,6 +4239,10 @@ function initGameControls(game: Game) {
 
   Utils.hideWithPoppers($('#puzzlebot-game-buttons'));
   Utils.hideWithPoppers($('#endgamebot-game-buttons'));
+  $('#left-panel-bottom').toggleClass('puzzlebot-active', game.puzzleBot && game.isExamining());
+  game.statusElement.find('.puzzlebot-status').hide();
+  game.statusElement.find('.game-status-outer').show();
+  game.statusElement.find('.game-watchers').toggle(!!game.statusElement.find('.game-watchers').html());
 
   if(game.endgameBot && game.isExamining()) {
     Utils.hideWithPoppers($('#playing-game-buttons'));
@@ -4248,6 +4254,7 @@ function initGameControls(game: Game) {
     Utils.hideWithPoppers($('#playing-game-buttons'));
     Utils.hideWithPoppers($('#viewing-game-buttons'));
     updatePuzzleBotControls(game);
+    updatePuzzleBotStatus(game);
     $('#puzzlebot-game-buttons').show();
   }
   else if(game.isPlaying()) {
@@ -4409,12 +4416,13 @@ function cleanupGame(game: Game) {
   game.role = Role.NONE;
   game.endgameBot = false;
   game.endgameBotEnded = false;
-  game.puzzleBot = false;
-  game.puzzleBotEnded = false;
-  game.puzzleBotWrongMove = false;
-  game.puzzleBotCommand = 'getmate';
+  game.puzzleBot = null;
+  game.statusElement.find('.puzzlebot-status').hide();
+  game.statusElement.find('.game-status-outer').show();
+  game.statusElement.find('.game-watchers').toggle(!!game.statusElement.find('.game-watchers').html());
 
   if(game === games.focused) {
+    $('#left-panel-bottom').removeClass('puzzlebot-active');
     hideHeaderFooterButton($('#stop-observing'));
     hideHeaderFooterButton($('#stop-examining'));
     hidePanel('#left-panel-header-2');
@@ -5923,19 +5931,28 @@ $('#puzzlebot-types').on('click', '[data-puzzlebot-command]', function() {
   puzzleBotRequestCommand = command;
   const game = games.focused;
   if(game?.puzzleBot && game.isExamining())
-    game.puzzleBotCommand = command;
+    game.puzzleBot.nextCommand = command;
   else
     sendPuzzleBotCommand(command, true);
 });
 
 $('#puzzlebot-hint').on('click', () => {
-  expectBotResponse('#puzzlebot-hint');
+  const game = games.focused;
+  if(game?.puzzleBot) {
+    game.puzzleBot.requestHint();
+    updatePuzzleBotControls(game);
+    updatePuzzleBotStatus(game);
+  }
   sendPuzzleBotCommand('hint');
 });
 
 $('#puzzlebot-solve').on('click', () => {
-  expectBotResponse('#puzzlebot-solve');
-  setPuzzleBotEnded(games.focused);
+  const game = games.focused;
+  if(game?.puzzleBot) {
+    game.puzzleBot.requestSolution();
+    updatePuzzleBotControls(game);
+    updatePuzzleBotStatus(game);
+  }
   sendPuzzleBotCommand('solve');
 });
 
@@ -5944,7 +5961,7 @@ $('#puzzlebot-next').on('click', () => {
   if(game?.puzzleBot && game.isExamining())
     session.send('unex');
 
-  sendPuzzleBotCommand(game?.puzzleBotCommand || 'getmate', true);
+  sendPuzzleBotCommand(game?.puzzleBot?.nextCommand || 'getmate', true);
 });
 
 $('#puzzlebot-stop').on('click', () => {
@@ -5967,6 +5984,7 @@ function sendPuzzleBotCommand(command: string, loadsPuzzle = false) {
 function beginPuzzleBotRequest(command: string) {
   clearEndgameBotRequest();
   clearBotResponsePopover();
+  pendingPuzzleBotMessages = [];
   puzzleBotRequestPending = true;
   puzzleBotRequestCommand = command;
   if(puzzleBotRequestTimer)
@@ -5976,60 +5994,87 @@ function beginPuzzleBotRequest(command: string) {
 
 function clearPuzzleBotRequest() {
   puzzleBotRequestPending = false;
+  pendingPuzzleBotMessages = [];
   if(puzzleBotRequestTimer)
     clearTimeout(puzzleBotRequestTimer);
   puzzleBotRequestTimer = null;
 }
 
-function setPuzzleBotEnded(game: Game, ended = true) {
+function setPuzzleBotEnded(game: Game) {
   if(!game?.puzzleBot)
     return;
 
-  game.puzzleBotEnded = ended;
-  if(ended)
-    game.puzzleBotWrongMove = false;
-  if(game === games.focused)
+  game.puzzleBot.finish();
+  if(game === games.focused) {
     updatePuzzleBotControls(game);
+    updatePuzzleBotStatus(game);
+  }
 }
 
 function updatePuzzleBotControls(game: Game) {
-  const wrongMove = game.puzzleBotWrongMove && !game.puzzleBotEnded;
+  const state = game.puzzleBot;
+  if(!state)
+    return;
+
+  const wrongMove = state.wrongMove && !state.ended;
   $('#puzzlebot-hint')
-    .prop('disabled', game.puzzleBotEnded)
+    .prop('disabled', state.ended)
     .toggleClass('btn-warning', wrongMove)
     .toggleClass('btn-outline-secondary', !wrongMove);
-  $('#puzzlebot-solve').prop('disabled', game.puzzleBotEnded);
+  $('#puzzlebot-solve').prop('disabled', state.ended);
   $('#puzzlebot-next')
-    .toggleClass('btn-success', game.puzzleBotEnded)
-    .toggleClass('btn-outline-secondary', !game.puzzleBotEnded);
+    .toggleClass('btn-success', state.ended)
+    .toggleClass('btn-outline-secondary', !state.ended);
+}
+
+function getPuzzleBotGame() {
+  if(games.focused?.puzzleBot)
+    return games.focused;
+
+  for(const game of games) {
+    if(game.puzzleBot)
+      return game;
+  }
+  return null;
+}
+
+function updatePuzzleBotStatus(game: Game) {
+  const state = game?.puzzleBot;
+  if(!state)
+    return;
+
+  const status = game.statusElement.find('.puzzlebot-status');
+  status.find('.puzzlebot-objective')
+    .text(state.objectiveText);
+  status.find('.puzzlebot-feedback')
+    .text(state.feedbackText)
+    .toggle(!!state.feedbackText);
+  game.statusElement.find('.game-status-outer, .game-watchers').hide();
+  status.show();
+
+  if(game === games.focused)
+    expandStatusPanel();
 }
 
 function handlePuzzleBotMessage(data: any) {
   if(data.user?.toLowerCase() !== 'puzzlebot')
-    return;
+    return false;
 
-  showExpectedBotResponse(data.message);
+  const message = data.message || '';
+  const game = getPuzzleBotGame();
+  const intercepted = !!game || puzzleBotRequestPending;
 
-  if(/There is a better move\./i.test(data.message || '')) {
-    for(const game of games) {
-      if(game.puzzleBot) {
-        game.puzzleBotWrongMove = true;
-        if(game === games.focused)
-          updatePuzzleBotControls(game);
-        return;
-      }
+  if(game) {
+    game.puzzleBot.recordMessage(message);
+    if(game === games.focused) {
+      updatePuzzleBotControls(game);
+      updatePuzzleBotStatus(game);
     }
   }
+  else if(puzzleBotRequestPending && message.trim())
+    pendingPuzzleBotMessages.push(message.trim());
 
-  if(!/You solved problem number/i.test(data.message || ''))
-    return;
-
-  for(const game of games) {
-    if(game.puzzleBot) {
-      setPuzzleBotEnded(game);
-      return;
-    }
-  }
+  return intercepted;
 }
 
 $('#endgamebot').on('click', '[data-endgamebot-pieceset]', function() {
@@ -6127,16 +6172,17 @@ function showExpectedBotResponse(message: string) {
   const target = botResponseTarget;
   botResponseTarget = null;
   const button = $(target);
-  button.tooltip('dispose');
-  button.popover({
+  const anchor = button.children('span').first();
+  button.tooltip('hide');
+  anchor.popover({
     content: message,
     container: 'body',
     placement: 'top',
     title: '',
     trigger: 'manual'
   });
-  button.popover('show');
-  activeBotResponsePopover = target;
+  anchor.popover('show');
+  activeBotResponsePopover = anchor;
   $('body').on('click.hide-bot-response', (e) => {
     if(!button.is(e.target)
         && button.has(e.target).length === 0
@@ -6152,11 +6198,7 @@ function clearBotResponsePopover() {
     clearTimeout(botResponsePopoverTimer);
   botResponsePopoverTimer = null;
   $('body').off('click.hide-bot-response');
-  if(activeBotResponsePopover) {
-    const button = $(activeBotResponsePopover);
-    button.popover('dispose');
-    Utils.createTooltip(button);
-  }
+  activeBotResponsePopover?.popover('dispose');
   activeBotResponsePopover = null;
 }
 
@@ -7171,7 +7213,8 @@ function initGameTools(game: Game) {
 }
 
 function canOpenAssociatedChat(game: Game) {
-  return !!chat && game.id != null && (game.isPlayingOnline() || game.isObserving() || game.isExamining());
+  return !!chat && !game.puzzleBot && game.id != null
+      && (game.isPlayingOnline() || game.isObserving() || game.isExamining());
 }
 
 function openAssociatedChatTab(game: Game, activateTab = false, expandChat = activateTab) {

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -24,6 +24,8 @@ import { Game, GameData, Role, NewVariationMode, games } from './game';
 import { History, HEntry } from './history';
 import { GetMessageType, MessageType, session, createSession } from './session';
 import { PuzzleBotState } from './puzzlebot';
+import { EndgameBotState } from './endgamebot';
+import { TrainingBotKind } from './trainingbot';
 import * as Sounds from './sounds';
 import { storage, CredentialStorage, awaiting } from './storage';
 import { settings } from './settings';
@@ -176,15 +178,13 @@ let sessionChannel: BroadcastChannel | null = null;
 let activeSessionTimer: number | null = null;
 let activeSessionOnLoad: { user: string; tabId: string; ts: number } | null = null;
 let followedTarget: string | null = null;
-let endgameBotRequestPending = false;
-let endgameBotRequestTimer: ReturnType<typeof setTimeout> | null = null;
-let puzzleBotRequestPending = false;
-let puzzleBotRequestCommand = 'getmate';
-let puzzleBotRequestTimer: ReturnType<typeof setTimeout> | null = null;
-let pendingPuzzleBotMessages: string[] = [];
-let botResponseTarget: string | null = null;
-let activeBotResponsePopover: JQuery<HTMLElement> | null = null;
-let botResponsePopoverTimer: ReturnType<typeof setTimeout> | null = null;
+let queuedEndgameBotCommand: string | null = null;
+let trainingBotRequest: {
+  kind: TrainingBotKind;
+  command: string;
+  messages: string[];
+  timer: ReturnType<typeof setTimeout> | null;
+} | null = null;
 
 /**
  * Used to call session.send() from inline JS.
@@ -1298,17 +1298,15 @@ function messageHandler(data: any) {
       }
       break;
     case MessageType.ChannelTell:
-      if(handlePuzzleBotMessage(data))
+      if(handleTrainingBotMessage(data))
         break;
-      handleEndgameBotMessage(data);
       chat.newMessage(data.channel, data);
       break;
     case MessageType.PrivateTell:
       if(handleInviteTell(data))
         return;
-      if(handlePuzzleBotMessage(data))
+      if(handleTrainingBotMessage(data))
         break;
-      handleEndgameBotMessage(data);
       chat.newMessage(data.user, data);
       break;
     case MessageType.Messages:
@@ -1464,14 +1462,12 @@ function gameStart(game: Game) {
   if(game === games.focused && (!game.history || !game.history.hasSubvariation()))
     $('#exit-subvariation').hide();
 
-  if(game.isExamining() && puzzleBotRequestPending) {
-    game.puzzleBot = new PuzzleBotState(puzzleBotRequestCommand, pendingPuzzleBotMessages);
-    clearPuzzleBotRequest();
-  }
-  else if(game.isExamining() && endgameBotRequestPending) {
-    game.endgameBot = true;
-    game.endgameBotEnded = false;
-    clearEndgameBotRequest();
+  if(game.isExamining() && trainingBotRequest) {
+    const request = trainingBotRequest;
+    game.trainingBot = request.kind === 'puzzle'
+      ? new PuzzleBotState(request.command, request.messages)
+      : new EndgameBotState(request.command, request.messages);
+    clearTrainingBotRequest();
   }
 
   // for bughouse set game.color of partner to opposite of us
@@ -1621,7 +1617,7 @@ function gameStart(game: Game) {
   if(chat)
     chat.closeUnusedPrivateTabs();
 
-  openAssociatedChatTab(game, game.endgameBot, false);
+  openAssociatedChatTab(game);
 
   if(game.isPlaying() || game.isObserving()) {
     // Adjust settings for game category (variant)
@@ -1722,10 +1718,8 @@ function gameEnd(data: any) {
   if(!game)
     return;
 
-  if(game.puzzleBot)
-    setPuzzleBotEnded(game);
-  if(game.endgameBot)
-    setEndgameBotEnded(game);
+  if(game.trainingBot)
+    setTrainingBotEnded(game);
 
   game.clock.stopClocks();
   // Set clock time to the time that the player resigns/aborts etc.
@@ -2081,7 +2075,7 @@ function handleMiscMessage(data: any) {
         }
       }
       game.statusElement.find('.game-watchers').html(req);
-      game.statusElement.find('.game-watchers').toggle(!!req && !game.puzzleBot);
+      game.statusElement.find('.game-watchers').toggle(!!req && !game.trainingBot);
       return;
     }
     chat.newMessage('console', data);
@@ -2961,9 +2955,8 @@ function handleMiscMessage(data: any) {
 export function cleanup() {
   chat?.cleanup();
   tournaments?.cleanup();
-  clearPuzzleBotRequest();
-  clearEndgameBotRequest();
-  clearBotResponsePopover();
+  clearTrainingBotRequest();
+  queuedEndgameBotCommand = null;
   awaiting.clearAll();
   setFollowedTarget(null);
   partnerGameId = null;
@@ -3510,10 +3503,10 @@ export function movePiece(source: any, target: any, metadata: any, pieceRole?: s
     sendMove(move);
 
   if(game.isExamining()) {
-    if(game.puzzleBot) {
-      game.puzzleBot.submitMove();
-      updatePuzzleBotControls(game);
-      updatePuzzleBotStatus(game);
+    if(game.trainingBot) {
+      game.trainingBot.submitMove();
+      updateTrainingBotControls(game);
+      updateTrainingBotStatus(game);
     }
 
     let nextMoveMatches = false;
@@ -4239,22 +4232,23 @@ function initGameControls(game: Game) {
 
   Utils.hideWithPoppers($('#puzzlebot-game-buttons'));
   Utils.hideWithPoppers($('#endgamebot-game-buttons'));
-  $('#left-panel-bottom').toggleClass('puzzlebot-active', game.puzzleBot && game.isExamining());
-  game.statusElement.find('.puzzlebot-status').hide();
+  $('#left-panel-bottom').toggleClass('trainingbot-active', !!game.trainingBot && game.isExamining());
+  game.statusElement.find('.trainingbot-status').hide();
   game.statusElement.find('.game-status-outer').show();
   game.statusElement.find('.game-watchers').toggle(!!game.statusElement.find('.game-watchers').html());
 
-  if(game.endgameBot && game.isExamining()) {
+  if(game.trainingBot?.kind === 'endgame' && game.isExamining()) {
     Utils.hideWithPoppers($('#playing-game-buttons'));
     Utils.hideWithPoppers($('#viewing-game-buttons'));
-    $('#endgamebot-hint, #endgamebot-move, #endgamebot-force').prop('disabled', game.endgameBotEnded);
+    updateTrainingBotControls(game);
+    updateTrainingBotStatus(game);
     $('#endgamebot-game-buttons').show();
   }
-  else if(game.puzzleBot && game.isExamining()) {
+  else if(game.trainingBot?.kind === 'puzzle' && game.isExamining()) {
     Utils.hideWithPoppers($('#playing-game-buttons'));
     Utils.hideWithPoppers($('#viewing-game-buttons'));
-    updatePuzzleBotControls(game);
-    updatePuzzleBotStatus(game);
+    updateTrainingBotControls(game);
+    updateTrainingBotStatus(game);
     $('#puzzlebot-game-buttons').show();
   }
   else if(game.isPlaying()) {
@@ -4408,21 +4402,20 @@ function removeGame(game: Game) {
 }
 
 function cleanupGame(game: Game) {
+  const restartEndgameBot = game.trainingBot?.kind === 'endgame' ? queuedEndgameBotCommand : null;
   if(playEngine && game.role === Role.PLAYING_COMPUTER) {
     playEngine.terminate();
     playEngine = null;
   }
 
   game.role = Role.NONE;
-  game.endgameBot = false;
-  game.endgameBotEnded = false;
-  game.puzzleBot = null;
-  game.statusElement.find('.puzzlebot-status').hide();
+  game.trainingBot = null;
+  game.statusElement.find('.trainingbot-status').hide();
   game.statusElement.find('.game-status-outer').show();
   game.statusElement.find('.game-watchers').toggle(!!game.statusElement.find('.game-watchers').html());
 
   if(game === games.focused) {
-    $('#left-panel-bottom').removeClass('puzzlebot-active');
+    $('#left-panel-bottom').removeClass('trainingbot-active');
     hideHeaderFooterButton($('#stop-observing'));
     hideHeaderFooterButton($('#stop-examining'));
     hidePanel('#left-panel-header-2');
@@ -4471,6 +4464,11 @@ function cleanupGame(game: Game) {
   game.pendingMoves = [];
   game.restoreMove = null;
   updateScreenWakeLock();
+
+  if(restartEndgameBot) {
+    queuedEndgameBotCommand = null;
+    setTimeout(() => sendEndgameBotCommand(restartEndgameBot, true));
+  }
 }
 
 /** *********************
@@ -5928,125 +5926,157 @@ function getGame(min: number, sec: number) {
 
 $('#puzzlebot-types').on('click', '[data-puzzlebot-command]', function() {
   const command = $(this).data('puzzlebot-command');
-  puzzleBotRequestCommand = command;
   const game = games.focused;
-  if(game?.puzzleBot && game.isExamining())
-    game.puzzleBot.nextCommand = command;
+  if(game?.trainingBot?.kind === 'puzzle' && game.isExamining())
+    game.trainingBot.nextCommand = command;
   else
     sendPuzzleBotCommand(command, true);
 });
 
 $('#puzzlebot-hint').on('click', () => {
   const game = games.focused;
-  if(game?.puzzleBot) {
-    game.puzzleBot.requestHint();
-    updatePuzzleBotControls(game);
-    updatePuzzleBotStatus(game);
+  if(game?.trainingBot?.kind === 'puzzle') {
+    game.trainingBot.requestFeedback();
+    updateTrainingBotControls(game);
+    updateTrainingBotStatus(game);
   }
   sendPuzzleBotCommand('hint');
 });
 
 $('#puzzlebot-solve').on('click', () => {
   const game = games.focused;
-  if(game?.puzzleBot) {
-    game.puzzleBot.requestSolution();
-    updatePuzzleBotControls(game);
-    updatePuzzleBotStatus(game);
+  if(game?.trainingBot instanceof PuzzleBotState) {
+    game.trainingBot.requestSolution();
+    updateTrainingBotControls(game);
+    updateTrainingBotStatus(game);
   }
   sendPuzzleBotCommand('solve');
 });
 
 $('#puzzlebot-next').on('click', () => {
   const game = games.focused;
-  if(game?.puzzleBot && game.isExamining())
+  const command = game?.trainingBot?.kind === 'puzzle'
+    ? game.trainingBot.nextCommand
+    : 'getmate';
+  if(game?.trainingBot?.kind === 'puzzle' && game.isExamining())
     session.send('unex');
 
-  sendPuzzleBotCommand(game?.puzzleBot?.nextCommand || 'getmate', true);
+  sendPuzzleBotCommand(command, true);
 });
 
 $('#puzzlebot-stop').on('click', () => {
-  clearPuzzleBotRequest();
-  clearBotResponsePopover();
+  clearTrainingBotRequest('puzzle');
   sendPuzzleBotCommand('stop');
   const game = games.focused;
-  if(game?.puzzleBot && game.isExamining())
+  if(game?.trainingBot?.kind === 'puzzle' && game.isExamining())
     session.send('unex');
 });
 
 function sendPuzzleBotCommand(command: string, loadsPuzzle = false) {
   if(loadsPuzzle)
-    beginPuzzleBotRequest(command);
+    beginTrainingBotRequest('puzzle', command);
 
   session.send(`t puzzlebot ${command}`);
   showTab($('#pills-game-tab'));
 }
 
-function beginPuzzleBotRequest(command: string) {
-  clearEndgameBotRequest();
-  clearBotResponsePopover();
-  pendingPuzzleBotMessages = [];
-  puzzleBotRequestPending = true;
-  puzzleBotRequestCommand = command;
-  if(puzzleBotRequestTimer)
-    clearTimeout(puzzleBotRequestTimer);
-  puzzleBotRequestTimer = setTimeout(clearPuzzleBotRequest, 10000);
-}
+$('#endgamebot').on('click', '[data-endgamebot-pieceset]', function() {
+  sendEndgameBotCommand(`play -f ${$(this).data('endgamebot-pieceset')}`, true);
+});
 
-function clearPuzzleBotRequest() {
-  puzzleBotRequestPending = false;
-  pendingPuzzleBotMessages = [];
-  if(puzzleBotRequestTimer)
-    clearTimeout(puzzleBotRequestTimer);
-  puzzleBotRequestTimer = null;
-}
+$('#endgamebot-hint').on('click', () => {
+  requestTrainingBotFeedback('endgame');
+  sendEndgameBotCommand('hint');
+});
 
-function setPuzzleBotEnded(game: Game) {
-  if(!game?.puzzleBot)
+$('#endgamebot-move').on('click', () => {
+  requestTrainingBotFeedback('endgame');
+  sendEndgameBotCommand('move');
+});
+
+$('#endgamebot-new').on('click', () => {
+  const game = games.focused;
+  if(game?.trainingBot?.kind !== 'endgame')
     return;
 
-  game.puzzleBot.finish();
+  queuedEndgameBotCommand = game.trainingBot.nextCommand;
+  clearTrainingBotRequest('endgame');
+  session.send('unex');
+});
+
+$('#endgamebot-stop').on('click', () => {
+  const game = games.focused;
+  clearTrainingBotRequest('endgame');
+  sendEndgameBotCommand('stop');
+  if(game?.trainingBot?.kind === 'endgame' && game.isExamining())
+    session.send('unex');
+});
+
+function sendEndgameBotCommand(command: string, loadsEndgame = false) {
+  if(loadsEndgame)
+    beginTrainingBotRequest('endgame', command);
+
+  session.send(`t endgamebot ${command}`);
+  showTab($('#pills-game-tab'));
+}
+
+function setTrainingBotEnded(game: Game) {
+  if(!game?.trainingBot)
+    return;
+
+  game.trainingBot.finish();
   if(game === games.focused) {
-    updatePuzzleBotControls(game);
-    updatePuzzleBotStatus(game);
+    updateTrainingBotControls(game);
+    updateTrainingBotStatus(game);
   }
 }
 
-function updatePuzzleBotControls(game: Game) {
-  const state = game.puzzleBot;
+function requestTrainingBotFeedback(kind: TrainingBotKind) {
+  const game = games.focused;
+  if(game?.trainingBot?.kind !== kind)
+    return;
+
+  game.trainingBot.requestFeedback();
+  updateTrainingBotStatus(game);
+}
+
+function updateTrainingBotControls(game: Game) {
+  const state = game?.trainingBot;
   if(!state)
     return;
 
-  const wrongMove = state.wrongMove && !state.ended;
-  $('#puzzlebot-hint')
-    .prop('disabled', state.ended)
+  const ended = state.ended;
+  const wrongMove = state.wrongMove && !ended;
+  if(state.kind === 'puzzle') {
+    $('#puzzlebot-hint')
+      .prop('disabled', ended)
+      .toggleClass('btn-warning', wrongMove)
+      .toggleClass('btn-outline-secondary', !wrongMove);
+    $('#puzzlebot-solve').prop('disabled', ended);
+    $('#puzzlebot-next')
+      .toggleClass('btn-success', ended)
+      .toggleClass('btn-outline-secondary', !ended);
+    return;
+  }
+
+  $('#endgamebot-hint, #endgamebot-move')
+    .prop('disabled', ended);
+  $('#endgamebot-hint')
     .toggleClass('btn-warning', wrongMove)
     .toggleClass('btn-outline-secondary', !wrongMove);
-  $('#puzzlebot-solve').prop('disabled', state.ended);
-  $('#puzzlebot-next')
-    .toggleClass('btn-success', state.ended)
-    .toggleClass('btn-outline-secondary', !state.ended);
+  $('#endgamebot-new')
+    .toggleClass('btn-success', ended)
+    .toggleClass('btn-outline-secondary', !ended);
 }
 
-function getPuzzleBotGame() {
-  if(games.focused?.puzzleBot)
-    return games.focused;
-
-  for(const game of games) {
-    if(game.puzzleBot)
-      return game;
-  }
-  return null;
-}
-
-function updatePuzzleBotStatus(game: Game) {
-  const state = game?.puzzleBot;
+function updateTrainingBotStatus(game: Game) {
+  const state = game?.trainingBot;
   if(!state)
     return;
 
-  const status = game.statusElement.find('.puzzlebot-status');
-  status.find('.puzzlebot-objective')
-    .text(state.objectiveText);
-  status.find('.puzzlebot-feedback')
+  const status = game.statusElement.find('.trainingbot-status');
+  status.find('.trainingbot-objective').text(state.objectiveText);
+  status.find('.trainingbot-feedback')
     .text(state.feedbackText)
     .toggle(!!state.feedbackText);
   game.statusElement.find('.game-status-outer, .game-watchers').hide();
@@ -6056,150 +6086,60 @@ function updatePuzzleBotStatus(game: Game) {
     expandStatusPanel();
 }
 
-function handlePuzzleBotMessage(data: any) {
-  if(data.user?.toLowerCase() !== 'puzzlebot')
+function getTrainingBotGame(kind: TrainingBotKind) {
+  if(games.focused?.trainingBot?.kind === kind)
+    return games.focused;
+
+  for(const game of games) {
+    if(game.trainingBot?.kind === kind)
+      return game;
+  }
+  return null;
+}
+
+function handleTrainingBotMessage(data: any) {
+  const user = data.user?.toLowerCase();
+  const kind: TrainingBotKind = user === 'puzzlebot'
+    ? 'puzzle'
+    : user === 'endgamebot' ? 'endgame' : null;
+  if(!kind)
     return false;
 
   const message = data.message || '';
-  const game = getPuzzleBotGame();
-  const intercepted = !!game || puzzleBotRequestPending;
+  const game = getTrainingBotGame(kind);
+  const request = trainingBotRequest?.kind === kind ? trainingBotRequest : null;
+  const intercepted = !!game || !!request;
 
   if(game) {
-    game.puzzleBot.recordMessage(message);
+    game.trainingBot.recordMessage(message);
     if(game === games.focused) {
-      updatePuzzleBotControls(game);
-      updatePuzzleBotStatus(game);
+      updateTrainingBotControls(game);
+      updateTrainingBotStatus(game);
     }
   }
-  else if(puzzleBotRequestPending && message.trim())
-    pendingPuzzleBotMessages.push(message.trim());
+  else if(request && message.trim())
+    request.messages.push(message.trim());
 
   return intercepted;
 }
 
-$('#endgamebot').on('click', '[data-endgamebot-pieceset]', function() {
-  sendEndgameBotCommand(`play ${$(this).data('endgamebot-pieceset')}`, true);
-});
-
-$('#endgamebot-back').on('click', () => {
-  clearBotResponsePopover();
-  setEndgameBotEnded(games.focused, false);
-  sendEndgameBotCommand('back');
-});
-
-$('#endgamebot-hint').on('click', () => {
-  expectBotResponse('#endgamebot-hint');
-  sendEndgameBotCommand('hint');
-});
-
-$('#endgamebot-move').on('click', () => {
-  expectBotResponse('#endgamebot-move');
-  sendEndgameBotCommand('move');
-});
-
-$('#endgamebot-force').on('click', () => {
-  sendEndgameBotCommand('force');
-});
-
-$('#endgamebot-stop').on('click', () => {
-  clearEndgameBotRequest();
-  clearBotResponsePopover();
-  sendEndgameBotCommand('stop');
-  const game = games.focused;
-  if(game?.endgameBot && game.isExamining())
-    session.send('unex');
-});
-
-function sendEndgameBotCommand(command: string, loadsEndgame = false) {
-  if(loadsEndgame)
-    beginEndgameBotRequest();
-
-  session.send(`t endgamebot ${command}`);
-  showTab($('#pills-game-tab'));
+function beginTrainingBotRequest(kind: TrainingBotKind, command: string) {
+  clearTrainingBotRequest();
+  const request = { kind, command, messages: [], timer: null };
+  request.timer = setTimeout(() => {
+    if(trainingBotRequest === request)
+      clearTrainingBotRequest();
+  }, 10000);
+  trainingBotRequest = request;
 }
 
-function beginEndgameBotRequest() {
-  clearPuzzleBotRequest();
-  clearBotResponsePopover();
-  endgameBotRequestPending = true;
-  if(endgameBotRequestTimer)
-    clearTimeout(endgameBotRequestTimer);
-  endgameBotRequestTimer = setTimeout(clearEndgameBotRequest, 10000);
-}
-
-function clearEndgameBotRequest() {
-  endgameBotRequestPending = false;
-  if(endgameBotRequestTimer)
-    clearTimeout(endgameBotRequestTimer);
-  endgameBotRequestTimer = null;
-}
-
-function setEndgameBotEnded(game: Game, ended = true) {
-  if(!game?.endgameBot)
+function clearTrainingBotRequest(kind?: TrainingBotKind) {
+  if(!trainingBotRequest || (kind && trainingBotRequest.kind !== kind))
     return;
 
-  game.endgameBotEnded = ended;
-  if(game === games.focused)
-    $('#endgamebot-hint, #endgamebot-move, #endgamebot-force').prop('disabled', ended);
-}
-
-function handleEndgameBotMessage(data: any) {
-  if(data.user?.toLowerCase() !== 'endgamebot')
-    return;
-
-  showExpectedBotResponse(data.message);
-
-  if(!/Thank you for playing endgamebot\./i.test(data.message || ''))
-    return;
-
-  for(const game of games) {
-    if(game.endgameBot) {
-      setEndgameBotEnded(game);
-      return;
-    }
-  }
-}
-
-function expectBotResponse(target: string) {
-  clearBotResponsePopover();
-  botResponseTarget = target;
-}
-
-function showExpectedBotResponse(message: string) {
-  if(!botResponseTarget || !message)
-    return;
-
-  const target = botResponseTarget;
-  botResponseTarget = null;
-  const button = $(target);
-  const anchor = button.children('span').first();
-  button.tooltip('hide');
-  anchor.popover({
-    content: message,
-    container: 'body',
-    placement: 'top',
-    title: '',
-    trigger: 'manual'
-  });
-  anchor.popover('show');
-  activeBotResponsePopover = anchor;
-  $('body').on('click.hide-bot-response', (e) => {
-    if(!button.is(e.target)
-        && button.has(e.target).length === 0
-        && !$(e.target).closest('.popover').length)
-      clearBotResponsePopover();
-  });
-  botResponsePopoverTimer = setTimeout(clearBotResponsePopover, 10000);
-}
-
-function clearBotResponsePopover() {
-  botResponseTarget = null;
-  if(botResponsePopoverTimer)
-    clearTimeout(botResponsePopoverTimer);
-  botResponsePopoverTimer = null;
-  $('body').off('click.hide-bot-response');
-  activeBotResponsePopover?.popover('dispose');
-  activeBotResponsePopover = null;
+  if(trainingBotRequest.timer)
+    clearTimeout(trainingBotRequest.timer);
+  trainingBotRequest = null;
 }
 
 function trackTrainingBotCommand(command: string) {
@@ -6208,14 +6148,14 @@ function trackTrainingBotCommand(command: string) {
     return;
 
   const bot = match[1].toLowerCase();
-  const botCommand = match[2].trim().toLowerCase();
+  const botCommand = match[2].trim();
   if(bot === 'puzzlebot') {
     const loadCommand = getPuzzleBotLoadCommand(botCommand);
     if(loadCommand)
-      beginPuzzleBotRequest(loadCommand);
+      beginTrainingBotRequest('puzzle', loadCommand);
   }
   else if(/^play(?:\s|$)/i.test(botCommand))
-    beginEndgameBotRequest();
+    beginTrainingBotRequest('endgame', botCommand);
 }
 
 function getPuzzleBotLoadCommand(command: string) {
@@ -7213,7 +7153,7 @@ function initGameTools(game: Game) {
 }
 
 function canOpenAssociatedChat(game: Game) {
-  return !!chat && !game.puzzleBot && game.id != null
+  return !!chat && !game.trainingBot && game.id != null
       && (game.isPlayingOnline() || game.isObserving() || game.isExamining());
 }
 

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -177,6 +177,10 @@ let sessionChannel: BroadcastChannel | null = null;
 let activeSessionTimer: number | null = null;
 let activeSessionOnLoad: { user: string; tabId: string; ts: number } | null = null;
 let followedTarget: string | null = null;
+let endgameBotRequestPending = false;
+let endgameBotRequestTimer: ReturnType<typeof setTimeout> | null = null;
+let puzzleBotRequestPending = false;
+let puzzleBotRequestTimer: ReturnType<typeof setTimeout> | null = null;
 
 /**
  * Used to call session.send() from inline JS.
@@ -853,9 +857,6 @@ $(window).on('resize', () => {
   setPanelSizes(false);
 
   prevSizeCategory = Utils.getSizeCategory();
-
-  if(evalEngine)
-    evalEngine.redraw();
 });
 
 function setPanelSizes(redrawBoard = true) {
@@ -962,6 +963,8 @@ function setLeftColumnSizes(redrawBoard = true) {
       setTimeout(() => { games.getMainGame()?.board?.redrawAll(); }, 0);
   
     seekGraph.update();
+    if(evalEngine)
+      evalEngine.redraw();
     resizeExplorer();
     History.scroller.fixScroll();
   }
@@ -1294,6 +1297,8 @@ function messageHandler(data: any) {
     case MessageType.PrivateTell:
       if(handleInviteTell(data))
         return;
+      handlePuzzleBotMessage(data);
+      handleEndgameBotMessage(data);
       chat.newMessage(data.user, data);
       break;
     case MessageType.Messages:
@@ -1449,6 +1454,17 @@ function gameStart(game: Game) {
   if(game === games.focused && (!game.history || !game.history.hasSubvariation()))
     $('#exit-subvariation').hide();
 
+  if(game.isExamining() && puzzleBotRequestPending) {
+    game.puzzleBot = true;
+    game.puzzleBotEnded = false;
+    clearPuzzleBotRequest();
+  }
+  else if(game.isExamining() && endgameBotRequestPending) {
+    game.endgameBot = true;
+    game.endgameBotEnded = false;
+    clearEndgameBotRequest();
+  }
+
   // for bughouse set game.color of partner to opposite of us
   const mainGame = games.getPlayingExaminingGame();
   const partnerColor = (mainGame && mainGame.partnerGameId === game.id && mainGame.color === 'w' ? 'b' : 'w');
@@ -1596,7 +1612,7 @@ function gameStart(game: Game) {
   if(chat)
     chat.closeUnusedPrivateTabs();
 
-  openAssociatedChatTab(game);
+  openAssociatedChatTab(game, game.puzzleBot || game.endgameBot, false);
 
   if(game.isPlaying() || game.isObserving()) {
     // Adjust settings for game category (variant)
@@ -1696,6 +1712,11 @@ function gameEnd(data: any) {
   const game = games.findGame(data.game_id);
   if(!game)
     return;
+
+  if(game.puzzleBot)
+    setPuzzleBotEnded(game);
+  if(game.endgameBot)
+    setEndgameBotEnded(game);
 
   game.clock.stopClocks();
   // Set clock time to the time that the player resigns/aborts etc.
@@ -4052,6 +4073,8 @@ function updateHistory(game: Game, move?: any, fen?: string, serverIssued = true
   game.history.display(hEntry, move && !sameMove);
   if(!sameMove)
     updateEngine();
+  if(game === games.focused && game.role === Role.NONE)
+    showAnalyzeButton();
 }
 
 /** ***************
@@ -4196,7 +4219,22 @@ function initGameControls(game: Game) {
   if(!game.history || !game.history.hasSubvariation())
     $('#exit-subvariation').hide();
 
-  if(game.isPlaying()) {
+  Utils.hideWithPoppers($('#puzzlebot-game-buttons'));
+  Utils.hideWithPoppers($('#endgamebot-game-buttons'));
+
+  if(game.endgameBot && game.isExamining()) {
+    Utils.hideWithPoppers($('#playing-game-buttons'));
+    Utils.hideWithPoppers($('#viewing-game-buttons'));
+    $('#endgamebot-hint, #endgamebot-move, #endgamebot-force').prop('disabled', game.endgameBotEnded);
+    $('#endgamebot-game-buttons').show();
+  }
+  else if(game.puzzleBot && game.isExamining()) {
+    Utils.hideWithPoppers($('#playing-game-buttons'));
+    Utils.hideWithPoppers($('#viewing-game-buttons'));
+    $('#puzzlebot-hint, #puzzlebot-solve').prop('disabled', game.puzzleBotEnded);
+    $('#puzzlebot-game-buttons').show();
+  }
+  else if(game.isPlaying()) {
     Utils.hideWithPoppers($('#viewing-game-buttons'));
 
     // show Adjourn button for standard time controls or slower
@@ -4353,6 +4391,10 @@ function cleanupGame(game: Game) {
   }
 
   game.role = Role.NONE;
+  game.endgameBot = false;
+  game.endgameBotEnded = false;
+  game.puzzleBot = false;
+  game.puzzleBotEnded = false;
 
   if(game === games.focused) {
     hideHeaderFooterButton($('#stop-observing'));
@@ -4361,6 +4403,8 @@ function cleanupGame(game: Game) {
     $('#takeback').prop('disabled', false);
     $('#play-computer').prop('disabled', false);
     Utils.hideWithPoppers($('#playing-game-buttons'));
+    Utils.hideWithPoppers($('#endgamebot-game-buttons'));
+    Utils.hideWithPoppers($('#puzzlebot-game-buttons'));
     $('#viewing-game-buttons').show();
     hideLobbyStatus();
   }
@@ -4659,7 +4703,7 @@ function hideHeaderFooterButton(button: JQuery<HTMLElement>) {
   if(!Utils.hideButton(button))
     return;
   const panel = button.closest('.card-header, .card-footer');
-  if((panel.attr('id') === 'left-panel-header-2' || Utils.isSmallWindow()) && !panel.find('.btn:visible').length) 
+  if((panel.attr('id') === 'left-panel-header-2' || Utils.isSmallWindow()) && !hasVisibleButton(panel))
     hidePanel(panel);
 }
 
@@ -5839,9 +5883,152 @@ function getGame(min: number, sec: number) {
 };
 
 $('#puzzlebot').on('click', () => {
-  session.send('t puzzlebot getmate');
-  showTab($('#pills-game-tab'));
+  sendPuzzleBotCommand('getmate', true);
 });
+
+$('#puzzlebot-hint').on('click', () => {
+  sendPuzzleBotCommand('hint');
+});
+
+$('#puzzlebot-solve').on('click', () => {
+  setPuzzleBotEnded(games.focused);
+  sendPuzzleBotCommand('solve');
+});
+
+$('#puzzlebot-next').on('click', () => {
+  const game = games.focused;
+  if(game?.puzzleBot && game.isExamining())
+    session.send('unex');
+
+  // PuzzleBot's sequential next command is restricted to registered users.
+  // Guests still get a useful Next Puzzle button by loading another random mate.
+  sendPuzzleBotCommand(session.isRegistered() ? 'next' : 'getmate', true);
+});
+
+$('#puzzlebot-stop').on('click', () => {
+  clearPuzzleBotRequest();
+  sendPuzzleBotCommand('stop');
+  const game = games.focused;
+  if(game?.puzzleBot && game.isExamining())
+    session.send('unex');
+});
+
+function sendPuzzleBotCommand(command: string, loadsPuzzle = false) {
+  if(loadsPuzzle) {
+    clearEndgameBotRequest();
+    puzzleBotRequestPending = true;
+    if(puzzleBotRequestTimer)
+      clearTimeout(puzzleBotRequestTimer);
+    puzzleBotRequestTimer = setTimeout(clearPuzzleBotRequest, 10000);
+  }
+
+  session.send(`t puzzlebot ${command}`);
+  showTab($('#pills-game-tab'));
+}
+
+function clearPuzzleBotRequest() {
+  puzzleBotRequestPending = false;
+  if(puzzleBotRequestTimer)
+    clearTimeout(puzzleBotRequestTimer);
+  puzzleBotRequestTimer = null;
+}
+
+function setPuzzleBotEnded(game: Game) {
+  if(!game?.puzzleBot)
+    return;
+
+  game.puzzleBotEnded = true;
+  if(game === games.focused)
+    $('#puzzlebot-hint, #puzzlebot-solve').prop('disabled', true);
+}
+
+function handlePuzzleBotMessage(data: any) {
+  if(data.user?.toLowerCase() !== 'puzzlebot')
+    return;
+
+  if(!/You solved problem number/i.test(data.message || ''))
+    return;
+
+  for(const game of games) {
+    if(game.puzzleBot) {
+      setPuzzleBotEnded(game);
+      return;
+    }
+  }
+}
+
+$('#endgamebot').on('click', '[data-endgamebot-pieceset]', function() {
+  sendEndgameBotCommand(`play ${$(this).data('endgamebot-pieceset')}`, true);
+});
+
+$('#endgamebot-back').on('click', () => {
+  setEndgameBotEnded(games.focused, false);
+  sendEndgameBotCommand('back');
+});
+
+$('#endgamebot-hint').on('click', () => {
+  sendEndgameBotCommand('hint');
+});
+
+$('#endgamebot-move').on('click', () => {
+  sendEndgameBotCommand('move');
+});
+
+$('#endgamebot-force').on('click', () => {
+  sendEndgameBotCommand('force');
+});
+
+$('#endgamebot-stop').on('click', () => {
+  clearEndgameBotRequest();
+  sendEndgameBotCommand('stop');
+  const game = games.focused;
+  if(game?.endgameBot && game.isExamining())
+    session.send('unex');
+});
+
+function sendEndgameBotCommand(command: string, loadsEndgame = false) {
+  if(loadsEndgame) {
+    clearPuzzleBotRequest();
+    endgameBotRequestPending = true;
+    if(endgameBotRequestTimer)
+      clearTimeout(endgameBotRequestTimer);
+    endgameBotRequestTimer = setTimeout(clearEndgameBotRequest, 10000);
+  }
+
+  session.send(`t endgamebot ${command}`);
+  showTab($('#pills-game-tab'));
+}
+
+function clearEndgameBotRequest() {
+  endgameBotRequestPending = false;
+  if(endgameBotRequestTimer)
+    clearTimeout(endgameBotRequestTimer);
+  endgameBotRequestTimer = null;
+}
+
+function setEndgameBotEnded(game: Game, ended = true) {
+  if(!game?.endgameBot)
+    return;
+
+  game.endgameBotEnded = ended;
+  if(game === games.focused)
+    $('#endgamebot-hint, #endgamebot-move, #endgamebot-force').prop('disabled', ended);
+}
+
+function handleEndgameBotMessage(data: any) {
+  if(data.user?.toLowerCase() !== 'endgamebot')
+    return;
+
+  if(!/Thank you for playing endgamebot\./i.test(data.message || ''))
+    return;
+
+  for(const game of games) {
+    if(game.endgameBot) {
+      setEndgameBotEnded(game);
+      return;
+    }
+  }
+}
 
 /** LOBBY PANE FUNCTIONS **/
 
@@ -6836,7 +7023,7 @@ function canOpenAssociatedChat(game: Game) {
   return !!chat && game.id != null && (game.isPlayingOnline() || game.isObserving() || game.isExamining());
 }
 
-function openAssociatedChatTab(game: Game, showTab = false) {
+function openAssociatedChatTab(game: Game, activateTab = false, expandChat = activateTab) {
   if(!canOpenAssociatedChat(game))
     return null;
 
@@ -6846,22 +7033,22 @@ function openAssociatedChatTab(game: Game, showTab = false) {
 
   if(game.isPlayingOnline()) {
     if(bughousePartnerGameId != null)
-      tab = chat.createTab(`Game ${game.id} and ${bughousePartnerGameId}`, showTab); // Open chat room for all bughouse participants
+      tab = chat.createTab(`Game ${game.id} and ${bughousePartnerGameId}`, activateTab); // Open chat room for all bughouse participants
     else if(game.color === 'w')
-      tab = chat.createTab(game.bname, showTab);
+      tab = chat.createTab(game.bname, activateTab);
     else
-      tab = chat.createTab(game.wname, showTab);
+      tab = chat.createTab(game.wname, activateTab);
   }
   else if(mainGame && game.id === mainGame.partnerGameId) { // Open chat to bughouse partner
     if(game.color === 'w')
-      tab = chat.createTab(game.wname, showTab);
+      tab = chat.createTab(game.wname, activateTab);
     else
-      tab = chat.createTab(game.bname, showTab);
+      tab = chat.createTab(game.bname, activateTab);
   }
   else
-    tab = chat.createTab(`Game ${game.id}`, showTab);
+    tab = chat.createTab(`Game ${game.id}`, activateTab);
 
-  if(showTab) {
+  if(activateTab && expandChat) {
     $('#collapse-chat').collapse('show');
     setTimeout(() => chat.scrollToChat(), 300);
   }
@@ -8233,7 +8420,7 @@ function initStatusPanel() {
   else {
     if(games.focused.analyzing) {
       showAnalysis();
-      evalEngine?.evaluate();
+      evalEngine?.redraw();
     }
     else
       hideAnalysis();
@@ -8287,8 +8474,6 @@ function expandStatusPanel(animate = false) {
       if(!Utils.isSmallWindow())
         $('#left-panel').css('transition', '');
       setLeftColumnSizes();
-      if($('#engine-tab').is(':visible') && evalEngine)
-        evalEngine.evaluate();
     });
     $('#left-panel-bottom-content').css('height', '');
     if(!Utils.isSmallWindow()) {
@@ -8299,8 +8484,6 @@ function expandStatusPanel(animate = false) {
   else { // Instantly show panel
     $('#left-panel-bottom').removeClass('minimized');
     setLeftColumnSizes();
-    if($('#engine-tab').is(':visible') && evalEngine)
-      evalEngine.evaluate();
   }
 }
 
@@ -8448,6 +8631,9 @@ async function showOpeningName(game: Game) {
 /** ANALYSIS FUNCTIONS **/
 
 (window as any).analyze = () => {
+  if(!canAnalyzeGame(games.focused))
+    return;
+
   showAnalysis();
   expandStatusPanel();
   scrollToLeftPanelBottom();
@@ -8928,6 +9114,11 @@ function removeAutoShape(game: Game, brush: string) {
 /** STATUS PANEL SHOW/HIDE BUTTON **/
 
 $('#analyze-btn').on('click', () => {
+  if(!canAnalyzeGame(games.focused)) {
+    hideHeaderFooterButton($('#analyze-btn'));
+    return;
+  }
+
   showAnalysis();
   expandStatusPanel();
   hideHeaderFooterButton($('#analyze-btn'));
@@ -8935,10 +9126,18 @@ $('#analyze-btn').on('click', () => {
 });
 
 function showAnalyzeButton() {
-  if(!$('#engine-tab').is(':visible') && Engine.categorySupported(games.focused.category))
+  if(!$('#engine-tab').is(':visible') && canAnalyzeGame(games.focused))
     showHeaderFooterButton($('#analyze-btn'));
   else 
     hideHeaderFooterButton($('#analyze-btn'));
+}
+
+function canAnalyzeGame(game: Game) {
+  if(!game?.history || game.isPlaying() || !Engine.categorySupported(game.category))
+    return false;
+
+  const standardStart = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+  return game.role !== Role.NONE || game.history.length() > 0 || game.history.first().fen !== standardStart;
 }
 
 /** ****************************

--- a/src/js/puzzlebot.ts
+++ b/src/js/puzzlebot.ts
@@ -1,0 +1,89 @@
+// Copyright 2026 Free Chess Club.
+// Use of this source code is governed by a GPL-style
+// license that can be found in the LICENSE file.
+
+const WRONG_MOVE_MESSAGE = /There is a better move\./i;
+const SOLVED_MESSAGE = /You solved problem number/i;
+const STATS_MESSAGE = /You made \d+ wrong moves?|needed \d+ hints?/i;
+const COMMAND_PROMPT = /\btype\s+"tell puzzlebot\b/i;
+
+export class PuzzleBotState {
+  ended = false;
+  feedbackPending = false;
+  feedbackMessages: string[] = [];
+  loadedCommand: string;
+  moveAttempted = false;
+  nextCommand: string;
+  objectiveMessages: string[];
+  wrongMove = false;
+
+  constructor(command = 'getmate', objectiveMessages: string[] = []) {
+    this.loadedCommand = command;
+    this.nextCommand = command;
+    this.objectiveMessages = objectiveMessages.filter(message => !COMMAND_PROMPT.test(message));
+  }
+
+  get objectiveText() {
+    return this.objectiveMessages.join('\n') || this.commandLabel();
+  }
+
+  get feedbackText() {
+    return this.feedbackMessages.slice(-2).join('\n');
+  }
+
+  requestHint() {
+    this.feedbackPending = true;
+    this.feedbackMessages = [];
+    this.wrongMove = false;
+  }
+
+  requestSolution() {
+    this.feedbackPending = true;
+    this.feedbackMessages = [];
+    this.finish();
+  }
+
+  submitMove() {
+    this.moveAttempted = true;
+    this.feedbackMessages = this.feedbackMessages.filter(message => !WRONG_MOVE_MESSAGE.test(message));
+    this.wrongMove = false;
+  }
+
+  finish() {
+    this.ended = true;
+    this.wrongMove = false;
+  }
+
+  recordMessage(message: string) {
+    const normalized = message?.trim();
+    if(!normalized || COMMAND_PROMPT.test(normalized))
+      return;
+
+    const solved = SOLVED_MESSAGE.test(normalized);
+    if(solved || this.feedbackPending)
+      this.feedbackMessages = [];
+
+    const feedback = this.feedbackPending || WRONG_MOVE_MESSAGE.test(normalized)
+        || solved || STATS_MESSAGE.test(normalized);
+    const messages = feedback || this.moveAttempted
+      ? this.feedbackMessages
+      : this.objectiveMessages;
+    if(messages[messages.length - 1] !== normalized)
+      messages.push(normalized);
+
+    if(this.feedbackPending)
+      this.feedbackPending = false;
+    if(WRONG_MOVE_MESSAGE.test(normalized))
+      this.wrongMove = true;
+    if(solved)
+      this.finish();
+  }
+
+  private commandLabel() {
+    if(this.loadedCommand.startsWith('gettactics'))
+      return 'Tactics Puzzle';
+    if(this.loadedCommand.startsWith('getstudy'))
+      return 'Chess Study';
+    return 'Mate Puzzle';
+  }
+}

--- a/src/js/puzzlebot.ts
+++ b/src/js/puzzlebot.ts
@@ -2,55 +2,28 @@
 // Use of this source code is governed by a GPL-style
 // license that can be found in the LICENSE file.
 
+import { TrainingBotState } from './trainingbot';
+
 const WRONG_MOVE_MESSAGE = /There is a better move\./i;
 const SOLVED_MESSAGE = /You solved problem number/i;
 const STATS_MESSAGE = /You made \d+ wrong moves?|needed \d+ hints?/i;
 const COMMAND_PROMPT = /\btype\s+"tell puzzlebot\b/i;
 
-export class PuzzleBotState {
-  ended = false;
-  feedbackPending = false;
-  feedbackMessages: string[] = [];
-  loadedCommand: string;
-  moveAttempted = false;
-  nextCommand: string;
-  objectiveMessages: string[];
-  wrongMove = false;
+export class PuzzleBotState extends TrainingBotState {
+  readonly kind = 'puzzle' as const;
 
   constructor(command = 'getmate', objectiveMessages: string[] = []) {
-    this.loadedCommand = command;
-    this.nextCommand = command;
-    this.objectiveMessages = objectiveMessages.filter(message => !COMMAND_PROMPT.test(message));
-  }
-
-  get objectiveText() {
-    return this.objectiveMessages.join('\n') || this.commandLabel();
-  }
-
-  get feedbackText() {
-    return this.feedbackMessages.slice(-2).join('\n');
-  }
-
-  requestHint() {
-    this.feedbackPending = true;
-    this.feedbackMessages = [];
-    this.wrongMove = false;
+    super(command, objectiveMessages.filter(message => !COMMAND_PROMPT.test(message)));
   }
 
   requestSolution() {
-    this.feedbackPending = true;
-    this.feedbackMessages = [];
+    this.requestFeedback();
     this.finish();
   }
 
   submitMove() {
-    this.moveAttempted = true;
+    this.interactionStarted = true;
     this.feedbackMessages = this.feedbackMessages.filter(message => !WRONG_MOVE_MESSAGE.test(message));
-    this.wrongMove = false;
-  }
-
-  finish() {
-    this.ended = true;
     this.wrongMove = false;
   }
 
@@ -65,7 +38,7 @@ export class PuzzleBotState {
 
     const feedback = this.feedbackPending || WRONG_MOVE_MESSAGE.test(normalized)
         || solved || STATS_MESSAGE.test(normalized);
-    const messages = feedback || this.moveAttempted
+    const messages = feedback || this.interactionStarted
       ? this.feedbackMessages
       : this.objectiveMessages;
     if(messages[messages.length - 1] !== normalized)
@@ -79,10 +52,10 @@ export class PuzzleBotState {
       this.finish();
   }
 
-  private commandLabel() {
-    if(this.loadedCommand.startsWith('gettactics'))
+  protected fallbackObjective() {
+    if(this.loadCommand.startsWith('gettactics'))
       return 'Tactics Puzzle';
-    if(this.loadedCommand.startsWith('getstudy'))
+    if(this.loadCommand.startsWith('getstudy'))
       return 'Chess Study';
     return 'Mate Puzzle';
   }

--- a/src/js/trainingbot.ts
+++ b/src/js/trainingbot.ts
@@ -1,0 +1,53 @@
+// Copyright 2026 Free Chess Club.
+// Use of this source code is governed by a GPL-style
+// license that can be found in the LICENSE file.
+
+export type TrainingBotKind = 'puzzle' | 'endgame';
+
+export abstract class TrainingBotState {
+  abstract readonly kind: TrainingBotKind;
+  ended = false;
+  feedbackPending = false;
+  feedbackMessages: string[] = [];
+  interactionStarted = false;
+  loadCommand: string;
+  nextCommand: string;
+  objectiveMessages: string[];
+  wrongMove = false;
+
+  constructor(command: string, objectiveMessages: string[] = []) {
+    this.loadCommand = command;
+    this.nextCommand = command;
+    this.objectiveMessages = objectiveMessages;
+  }
+
+  get objectiveText() {
+    return this.objectiveMessages.join('\n') || this.fallbackObjective();
+  }
+
+  get feedbackText() {
+    return this.feedbackMessages.slice(-2).join('\n');
+  }
+
+  requestFeedback() {
+    this.feedbackPending = true;
+    this.feedbackMessages = [];
+    this.interactionStarted = true;
+    this.wrongMove = false;
+  }
+
+  submitMove() {
+    this.interactionStarted = true;
+    this.feedbackMessages = [];
+    this.wrongMove = false;
+  }
+
+  finish() {
+    this.ended = true;
+    this.wrongMove = false;
+  }
+
+  abstract recordMessage(message: string): void;
+
+  protected abstract fallbackObjective(): string;
+}

--- a/src/js/utils.ts
+++ b/src/js/utils.ts
@@ -711,7 +711,7 @@ export function insertAtCursor(element: JQuery<HTMLElement>, text: string) {
  * Set the margin of the last visible button to 0
  */
 export function showButton(button: any): boolean {
-  if(button.is(':visible'))
+  if(button[0].style.display !== 'none')
     return false;
 
   button.show();
@@ -724,7 +724,7 @@ export function showButton(button: any): boolean {
  * Set the margin of the last visible button to 0
  */
 export function hideButton(button: any): boolean {
-  if(!button.is(':visible'))
+  if(button[0].style.display === 'none')
     return false;
 
   button.hide();

--- a/src/play.html
+++ b/src/play.html
@@ -303,16 +303,16 @@
                                     <button type="button" class="btn btn-outline-secondary btn-md" id="puzzlebot">Puzzle</button>
                                     <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Endgames</button>
                                     <ul class="dropdown-menu dropdown-menu-end" id="endgamebot">
-                                      <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play kpk'); showGameTab();">kpk</a></li>
-                                      <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play kbnk'); showGameTab();">kbnk</a></li>
-                                      <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play kbbk'); showGameTab();">kbbk</a></li>
-                                      <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play kqk'); showGameTab();">kqk</a></li>
-                                      <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play krpkr'); showGameTab();">krpkr</a></li>
-                                      <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play krk'); showGameTab();">krk</a></li>
-                                      <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play kqkr'); showGameTab();">kqkr</a></li>
-                                      <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play kpkp'); showGameTab();">kpkp</a></li>
-                                      <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play kqpkq'); showGameTab();">kqpkq</a></li>
-                                      <li><a class="dropdown-item" onclick="sessionSend('t endgamebot play knnkp'); showGameTab();">knnkp</a></li>
+                                      <li><a class="dropdown-item" data-endgamebot-pieceset="kpk">kpk</a></li>
+                                      <li><a class="dropdown-item" data-endgamebot-pieceset="kbnk">kbnk</a></li>
+                                      <li><a class="dropdown-item" data-endgamebot-pieceset="kbbk">kbbk</a></li>
+                                      <li><a class="dropdown-item" data-endgamebot-pieceset="kqk">kqk</a></li>
+                                      <li><a class="dropdown-item" data-endgamebot-pieceset="krpkr">krpkr</a></li>
+                                      <li><a class="dropdown-item" data-endgamebot-pieceset="krk">krk</a></li>
+                                      <li><a class="dropdown-item" data-endgamebot-pieceset="kqkr">kqkr</a></li>
+                                      <li><a class="dropdown-item" data-endgamebot-pieceset="kpkp">kpkp</a></li>
+                                      <li><a class="dropdown-item" data-endgamebot-pieceset="kqpkq">kqpkq</a></li>
+                                      <li><a class="dropdown-item" data-endgamebot-pieceset="knnkp">knnkp</a></li>
                                     </ul>
                                   </div>
                                 </div>
@@ -798,6 +798,37 @@
                   </button>
                   <button type="button" id="resign" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Resign">
                     <span class="fa-regular fa-flag" aria-hidden="false"></span>
+                  </button>
+                </div>
+                <div id="puzzlebot-game-buttons" class="button-toolbar flex-wrap w-100" style="display: none" aria-label="Puzzle controls">
+                  <button type="button" id="puzzlebot-hint" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Hint" aria-label="Hint">
+                    <span class="fa-regular fa-lightbulb" aria-hidden="true"></span>
+                  </button>
+                  <button type="button" id="puzzlebot-solve" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Show Solution" aria-label="Show Solution">
+                    <span class="fa-solid fa-list-check" aria-hidden="true"></span>
+                  </button>
+                  <button type="button" id="puzzlebot-next" class="btn btn-outline-secondary btn-md" title="Next Puzzle">
+                    Next Puzzle<span class="fa-solid fa-forward-step ms-2" aria-hidden="true"></span>
+                  </button>
+                  <button type="button" id="puzzlebot-stop" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Stop Puzzles" aria-label="Stop Puzzles">
+                    <span class="fa-solid fa-circle-xmark" aria-hidden="true"></span>
+                  </button>
+                </div>
+                <div id="endgamebot-game-buttons" class="button-toolbar flex-wrap w-100" style="display: none" aria-label="Endgame controls">
+                  <button type="button" id="endgamebot-back" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Take Back Move" aria-label="Take Back Move">
+                    <span class="fa-solid fa-rotate-left" aria-hidden="true"></span>
+                  </button>
+                  <button type="button" id="endgamebot-hint" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Hint" aria-label="Hint">
+                    <span class="fa-regular fa-lightbulb" aria-hidden="true"></span>
+                  </button>
+                  <button type="button" id="endgamebot-move" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Play Best Move" aria-label="Play Best Move">
+                    <span class="fa-solid fa-forward-step" aria-hidden="true"></span>
+                  </button>
+                  <button type="button" id="endgamebot-force" class="btn btn-outline-secondary btn-md" title="Toggle Force Mode">
+                    Force
+                  </button>
+                  <button type="button" id="endgamebot-stop" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Stop Endgame" aria-label="Stop Endgame">
+                    <span class="fa-solid fa-circle-xmark" aria-hidden="true"></span>
                   </button>
                 </div>
                 <div id="viewing-game-buttons" class="button-toolbar w-100">

--- a/src/play.html
+++ b/src/play.html
@@ -299,16 +299,13 @@
                                       <use href="#icon-info" />
                                     </svg>
                                   </div>
-                                  <div class="btn-group dropdown position-static" role="group" aria-label="Puzzle type">
-                                    <button type="button" class="btn btn-outline-secondary btn-md" id="puzzlebot" data-puzzlebot-command="getmate">Mate Puzzle</button>
-                                    <button class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Select puzzle type"></button>
+                                  <div class="btn-group dropdown position-static" role="group" aria-label="Study">
+                                    <button class="btn btn-outline-secondary dropdown-toggle" id="puzzlebot" type="button" data-bs-toggle="dropdown" aria-expanded="false">Puzzle</button>
                                     <ul class="dropdown-menu" id="puzzlebot-types">
                                       <li><a class="dropdown-item" data-puzzlebot-command="getmate">Mate Puzzle</a></li>
                                       <li><a class="dropdown-item" data-puzzlebot-command="gettactics">Tactics Puzzle</a></li>
                                       <li><a class="dropdown-item" data-puzzlebot-command="getstudy">Chess Study</a></li>
                                     </ul>
-                                  </div>
-                                  <div class="btn-group dropdown position-static" role="group" aria-label="Endgame type">
                                     <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Endgames</button>
                                     <ul class="dropdown-menu dropdown-menu-end" id="endgamebot">
                                       <li><a class="dropdown-item" data-endgamebot-pieceset="kpk">kpk</a></li>
@@ -809,10 +806,10 @@
                   </button>
                 </div>
                 <div id="puzzlebot-game-buttons" class="button-toolbar flex-wrap w-100" style="display: none" aria-label="Puzzle controls">
-                  <button type="button" id="puzzlebot-hint" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Hint" aria-label="Hint">
+                  <button type="button" id="puzzlebot-hint" class="btn btn-outline-secondary btn-md" data-tooltip-hover-only data-bs-toggle="tooltip" data-bs-placement="top" title="Hint" aria-label="Hint">
                     <span class="fa-regular fa-lightbulb" aria-hidden="true"></span>
                   </button>
-                  <button type="button" id="puzzlebot-solve" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Show Solution" aria-label="Show Solution">
+                  <button type="button" id="puzzlebot-solve" class="btn btn-outline-secondary btn-md" data-tooltip-hover-only data-bs-toggle="tooltip" data-bs-placement="top" title="Show Solution" aria-label="Show Solution">
                     <span class="fa-solid fa-list-check" aria-hidden="true"></span>
                   </button>
                   <button type="button" id="puzzlebot-next" class="btn btn-outline-secondary btn-md" title="Next Puzzle">
@@ -826,10 +823,10 @@
                   <button type="button" id="endgamebot-back" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Take Back Move" aria-label="Take Back Move">
                     <span class="fa-solid fa-rotate-left" aria-hidden="true"></span>
                   </button>
-                  <button type="button" id="endgamebot-hint" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Hint" aria-label="Hint">
+                  <button type="button" id="endgamebot-hint" class="btn btn-outline-secondary btn-md" data-tooltip-hover-only data-bs-toggle="tooltip" data-bs-placement="top" title="Hint" aria-label="Hint">
                     <span class="fa-regular fa-lightbulb" aria-hidden="true"></span>
                   </button>
-                  <button type="button" id="endgamebot-move" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Play Best Move" aria-label="Play Best Move">
+                  <button type="button" id="endgamebot-move" class="btn btn-outline-secondary btn-md" data-tooltip-hover-only data-bs-toggle="tooltip" data-bs-placement="top" title="Play Best Move" aria-label="Play Best Move">
                     <span class="fa-solid fa-forward-step" aria-hidden="true"></span>
                   </button>
                   <button type="button" id="endgamebot-force" class="btn btn-outline-secondary btn-md" title="Toggle Force Mode">

--- a/src/play.html
+++ b/src/play.html
@@ -738,9 +738,9 @@
                           <div class="game-info px-2">
                             <div class="game-status-outer center" style="text-align: center"><span class="game-status"></span></div>
                             <div class="game-watchers center flex-wrap border-top" style="display: none;"></div>
-                            <div class="puzzlebot-status text-center" style="display: none" aria-live="polite">
-                              <div class="puzzlebot-objective fw-bold"></div>
-                              <div class="puzzlebot-feedback small mt-1"></div>
+                            <div class="trainingbot-status text-center" style="display: none" aria-live="polite">
+                              <div class="trainingbot-objective fw-bold"></div>
+                              <div class="trainingbot-feedback small mt-1"></div>
                             </div>
                           </div>
                         </div>
@@ -824,17 +824,14 @@
                   </button>
                 </div>
                 <div id="endgamebot-game-buttons" class="button-toolbar flex-wrap w-100" style="display: none" aria-label="Endgame controls">
-                  <button type="button" id="endgamebot-back" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Take Back Move" aria-label="Take Back Move">
-                    <span class="fa-solid fa-rotate-left" aria-hidden="true"></span>
-                  </button>
                   <button type="button" id="endgamebot-hint" class="btn btn-outline-secondary btn-md" data-tooltip-hover-only data-bs-toggle="tooltip" data-bs-placement="top" title="Hint" aria-label="Hint">
                     <span class="fa-regular fa-lightbulb" aria-hidden="true"></span>
                   </button>
                   <button type="button" id="endgamebot-move" class="btn btn-outline-secondary btn-md" data-tooltip-hover-only data-bs-toggle="tooltip" data-bs-placement="top" title="Play Best Move" aria-label="Play Best Move">
-                    <span class="fa-solid fa-forward-step" aria-hidden="true"></span>
+                    <span class="fa-solid fa-list-check" aria-hidden="true"></span>
                   </button>
-                  <button type="button" id="endgamebot-force" class="btn btn-outline-secondary btn-md" title="Toggle Force Mode">
-                    Force
+                  <button type="button" id="endgamebot-new" class="btn btn-outline-secondary btn-md" data-tooltip-hover-only data-bs-toggle="tooltip" data-bs-placement="top" title="New Game" aria-label="New Game">
+                    New Game<span class="fa-solid fa-forward-step ms-2" aria-hidden="true"></span>
                   </button>
                   <button type="button" id="endgamebot-stop" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Stop Endgame" aria-label="Stop Endgame">
                     <span class="fa-solid fa-circle-xmark" aria-hidden="true"></span>

--- a/src/play.html
+++ b/src/play.html
@@ -299,8 +299,16 @@
                                       <use href="#icon-info" />
                                     </svg>
                                   </div>
-                                  <div class="btn-group dropdown position-static" role="group" aria-label="Study">
-                                    <button type="button" class="btn btn-outline-secondary btn-md" id="puzzlebot">Puzzle</button>
+                                  <div class="btn-group dropdown position-static" role="group" aria-label="Puzzle type">
+                                    <button type="button" class="btn btn-outline-secondary btn-md" id="puzzlebot" data-puzzlebot-command="getmate">Mate Puzzle</button>
+                                    <button class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Select puzzle type"></button>
+                                    <ul class="dropdown-menu" id="puzzlebot-types">
+                                      <li><a class="dropdown-item" data-puzzlebot-command="getmate">Mate Puzzle</a></li>
+                                      <li><a class="dropdown-item" data-puzzlebot-command="gettactics">Tactics Puzzle</a></li>
+                                      <li><a class="dropdown-item" data-puzzlebot-command="getstudy">Chess Study</a></li>
+                                    </ul>
+                                  </div>
+                                  <div class="btn-group dropdown position-static" role="group" aria-label="Endgame type">
                                     <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Endgames</button>
                                     <ul class="dropdown-menu dropdown-menu-end" id="endgamebot">
                                       <li><a class="dropdown-item" data-endgamebot-pieceset="kpk">kpk</a></li>

--- a/src/play.html
+++ b/src/play.html
@@ -738,6 +738,10 @@
                           <div class="game-info px-2">
                             <div class="game-status-outer center" style="text-align: center"><span class="game-status"></span></div>
                             <div class="game-watchers center flex-wrap border-top" style="display: none;"></div>
+                            <div class="puzzlebot-status text-center" style="display: none" aria-live="polite">
+                              <div class="puzzlebot-objective fw-bold"></div>
+                              <div class="puzzlebot-feedback small mt-1"></div>
+                            </div>
                           </div>
                         </div>
                       </div>

--- a/src/play.html
+++ b/src/play.html
@@ -819,7 +819,7 @@
                   <button type="button" id="puzzlebot-next" class="btn btn-outline-secondary btn-md" title="Next Puzzle">
                     Next Puzzle<span class="fa-solid fa-forward-step ms-2" aria-hidden="true"></span>
                   </button>
-                  <button type="button" id="puzzlebot-stop" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Stop Puzzles" aria-label="Stop Puzzles">
+                  <button type="button" id="puzzlebot-stop" class="btn btn-outline-secondary btn-md" data-tooltip-hover-only data-bs-toggle="tooltip" data-bs-placement="top" title="Stop Puzzles" aria-label="Stop Puzzles">
                     <span class="fa-solid fa-circle-xmark" aria-hidden="true"></span>
                   </button>
                 </div>
@@ -833,7 +833,7 @@
                   <button type="button" id="endgamebot-new" class="btn btn-outline-secondary btn-md" data-tooltip-hover-only data-bs-toggle="tooltip" data-bs-placement="top" title="New Game" aria-label="New Game">
                     New Game<span class="fa-solid fa-forward-step ms-2" aria-hidden="true"></span>
                   </button>
-                  <button type="button" id="endgamebot-stop" class="btn btn-outline-secondary btn-md" data-bs-toggle="tooltip" data-bs-placement="top" title="Stop Endgame" aria-label="Stop Endgame">
+                  <button type="button" id="endgamebot-stop" class="btn btn-outline-secondary btn-md" data-tooltip-hover-only data-bs-toggle="tooltip" data-bs-placement="top" title="Stop Endgame" aria-label="Stop Endgame">
                     <span class="fa-solid fa-circle-xmark" aria-hidden="true"></span>
                   </button>
                 </div>


### PR DESCRIPTION
Adds dedicated UI controls for PuzzleBot and EndgameBot and improves training-mode behavior.

## Changes

* Added PuzzleBot controls for Hint, Show Solution, Next Puzzle, and Stop.
* Added EndgameBot controls for Back, Hint, Play Best Move, Force, and Stop.
* Made game chat automatically active in PuzzleBot and EndgameBot modes.
* Disabled assistance controls after completion:
  * PuzzleBot: detects `You solved problem number`.
  * EndgameBot: detects `Thank you for playing endgamebot`.
* Made Next Puzzle work for registered users and load a random mate for guests.
* Properly exits the current examined position when stopping or advancing.
* Hid Analyze when no game or meaningful position is loaded.
* Prevented Analyze from opening an empty evaluation graph.