### PR TITLE
Relax EndgameBot training by default

### DIFF
--- a/src/js/endgamebot.ts
+++ b/src/js/endgamebot.ts
@@ -19,10 +19,15 @@ function normalizeMessage(message: string) {
 export class EndgameBotState extends TrainingBotState {
   readonly kind = 'endgame' as const;
 
-  constructor(playCommand = 'play -f kpk', objectiveMessages: string[] = []) {
+  constructor(playCommand = 'play kpk', objectiveMessages: string[] = []) {
     super(playCommand, objectiveMessages
       .map(normalizeMessage)
       .filter(message => message && !COMMAND_PROMPT.test(message)));
+  }
+
+  takeBack() {
+    this.ended = false;
+    this.requestFeedback();
   }
 
   finish() {
@@ -46,7 +51,9 @@ export class EndgameBotState extends TrainingBotState {
     const messages = this.feedbackPending || completed || this.interactionStarted
       ? this.feedbackMessages
       : this.objectiveMessages;
-    if(messages[messages.length - 1] !== normalized)
+    const repeatsObjective = messages === this.feedbackMessages
+      && this.objectiveMessages[this.objectiveMessages.length - 1] === normalized;
+    if(!repeatsObjective && messages[messages.length - 1] !== normalized)
       messages.push(normalized);
 
     if(this.feedbackPending)

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -4788,6 +4788,14 @@ $('#backward').on('click', () => {
 
 function backward() {
   const game = games.focused;
+  if(game?.trainingBot instanceof EndgameBotState && game.isExamining()) {
+    game.trainingBot.takeBack();
+    updateTrainingBotControls(game);
+    updateTrainingBotStatus(game);
+    sendEndgameBotCommand('back');
+    return;
+  }
+
   const move = game.history.prev();
 
   if(move)
@@ -6274,7 +6282,7 @@ function sendPuzzleBotCommand(command: string, loadsPuzzle = false) {
 }
 
 $('#endgamebot').on('click', '[data-endgamebot-pieceset]', function() {
-  sendEndgameBotCommand(`play -f ${$(this).data('endgamebot-pieceset')}`, true);
+  sendEndgameBotCommand(`play ${$(this).data('endgamebot-pieceset')}`, true);
 });
 
 $('#endgamebot-hint').on('click', () => {


### PR DESCRIPTION
## Summary
- start EndgameBot positions in relaxed mode instead of forcing the fastest line
- make the existing Back navigation control send EndgameBot's takeback command
- clear completed state on takeback and avoid repeating the restored objective as feedback

## Verification
- `npm run bundle`
- `npx eslint src/js/endgamebot.ts`
- live-tested relaxed starts and takeback against EndgameBot
- checked desktop and mobile layouts